### PR TITLE
Stripping quotation marks of argument default value

### DIFF
--- a/config/sets/laravel60.php
+++ b/config/sets/laravel60.php
@@ -95,10 +95,10 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         ->call('configure', [[
             ArgumentAdderRector::ADDED_ARGUMENTS => ValueObjectInliner::inline([
                 // https://github.com/laravel/framework/commit/6c1e014943a508afb2c10869c3175f7783a004e1
-                new ArgumentAdder('Illuminate\Database\Capsule\Manager', 'table', 1, 'as', 'null'),
-                new ArgumentAdder('Illuminate\Database\Connection', 'table', 1, 'as', 'null'),
-                new ArgumentAdder('Illuminate\Database\ConnectionInterface', 'table', 1, 'as', 'null'),
-                new ArgumentAdder('Illuminate\Database\Query\Builder', 'from', 1, 'as', 'null'),
+                new ArgumentAdder('Illuminate\Database\Capsule\Manager', 'table', 1, 'as', null),
+                new ArgumentAdder('Illuminate\Database\Connection', 'table', 1, 'as', null),
+                new ArgumentAdder('Illuminate\Database\ConnectionInterface', 'table', 1, 'as', null),
+                new ArgumentAdder('Illuminate\Database\Query\Builder', 'from', 1, 'as', null),
             ]),
         ]]);
 };


### PR DESCRIPTION
When `LaravelSetList::LARAVEL_60` applied, the code changes as below:

```diff
-DB::connection($connection)->table($table);
+DB::connection($connection)->table($table, 'null');
```

Expected Behavior:

```diff
-DB::connection($connection)->table($table);
+DB::connection($connection)->table($table, null);
```

Related rectorphp/rector#5997 