### PR TITLE
Add set for Laravel 7.x

### DIFF
--- a/config/sets/laravel70.php
+++ b/config/sets/laravel70.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPStan\Type\ObjectType;
+use Rector\Arguments\Rector\ClassMethod\ArgumentAdderRector;
+use Rector\Arguments\ValueObject\ArgumentAdder;
+use Rector\Renaming\Rector\MethodCall\RenameMethodRector;
+use Rector\Renaming\Rector\Name\RenameClassRector;
+use Rector\Renaming\ValueObject\MethodCallRename;
+use Rector\TypeDeclaration\Rector\ClassMethod\AddParamTypeDeclarationRector;
+use Rector\TypeDeclaration\ValueObject\AddParamTypeDeclaration;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Symplify\SymfonyPhpConfig\ValueObjectInliner;
+
+# see https://laravel.com/docs/7.x/upgrade
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $services = $containerConfigurator->services();
+
+    # https://github.com/laravel/framework/pull/30610/files
+    $services->set(AddParamTypeDeclarationRector::class)
+        ->call('configure', [[
+            AddParamTypeDeclarationRector::PARAMETER_TYPEHINTS => ValueObjectInliner::inline([
+                new AddParamTypeDeclaration(
+                    'Illuminate\Contracts\Debug\ExceptionHandler',
+                    'report',
+                    0,
+                    new ObjectType('Throwable')
+                ),
+                new AddParamTypeDeclaration(
+                    'Illuminate\Contracts\Debug\ExceptionHandler',
+                    'shouldReport',
+                    0,
+                    new ObjectType('Throwable')
+                ),
+                new AddParamTypeDeclaration(
+                    'Illuminate\Contracts\Debug\ExceptionHandler',
+                    'render',
+                    1,
+                    new ObjectType('Throwable')
+                ),
+                new AddParamTypeDeclaration(
+                    'Illuminate\Contracts\Debug\ExceptionHandler',
+                    'renderForConsole',
+                    1,
+                    new ObjectType('Throwable')
+                ),
+            ]),
+        ]]);
+
+    # https://github.com/laravel/framework/pull/30471/files
+    $services->set(ArgumentAdderRector::class)
+        ->call('configure', [[
+            ArgumentAdderRector::ADDED_ARGUMENTS => ValueObjectInliner::inline([
+                new ArgumentAdder(
+                    'Illuminate\Contracts\Routing\UrlRoutable',
+                    'resolveRouteBinding',
+                    1,
+                    'field',
+                    null
+                ),
+            ]),
+        ]]);
+
+    $services->set(RenameMethodRector::class)
+        ->call('configure', [[
+            RenameMethodRector::METHOD_CALL_RENAMES => ValueObjectInliner::inline([
+                # https://github.com/laravel/framework/commit/aece7d78f3d28b2cdb63185dcc4a9b6092841310
+                new MethodCallRename('Illuminate\Support\Facades\Blade', 'component', 'aliasComponent'),
+                # https://github.com/laravel/framework/pull/31463/files
+                new MethodCallRename(
+                    'Illuminate\Database\Eloquent\Concerns\HidesAttributes',
+                    'addHidden',
+                    'makeHidden'
+                ),
+                # https://github.com/laravel/framework/pull/30348/files
+                new MethodCallRename(
+                    'Illuminate\Database\Eloquent\Concerns\HidesAttributes',
+                    'addVisible',
+                    'makeVisible'
+                ),
+            ]),
+        ]]);
+    $services->set(RenameClassRector::class)
+        ->call('configure', [[
+            RenameClassRector::OLD_TO_NEW_CLASSES => [
+                # https://github.com/laravel/framework/pull/30619/files
+                'Illuminate\Http\Resources\Json\Resource' => 'Illuminate\Http\Resources\Json\JsonResource',
+                # https://github.com/laravel/framework/pull/31050/files
+                'Illuminate\Foundation\Testing\TestResponse' => 'Illuminate\Testing\TestResponse',
+                'Illuminate\Foundation\Testing\Assert' => 'Illuminate\Testing\Assert',
+            ],
+        ]]);
+};

--- a/src/Set/LaravelSetList.php
+++ b/src/Set/LaravelSetList.php
@@ -66,6 +66,11 @@ final class LaravelSetList implements SetListInterface
     /**
      * @var string
      */
+    public const LARAVEL_70 = __DIR__ . '/../../config/sets/laravel70.php';
+
+    /**
+     * @var string
+     */
     public const LARAVEL_STATIC_TO_INJECTION = __DIR__ . '/../../config/sets/laravel-static-to-injection.php';
 
     /**


### PR DESCRIPTION
- [x] Method rename

  - [x] The `Blade::component` method has been renamed to `Blade::aliasComponent`. https://github.com/laravel/framework/commit/aece7d78f3d28b2cdb63185dcc4a9b6092841310

  - [x] The undocumented `addHidden` and `addVisible` methods have been removed. Instead, please use the `makeHidden` and `makeVisible` methods. https://github.com/laravel/framework/pull/30348, https://github.com/laravel/framework/pull/31463

- [x] Parameter type changed

  - [x] The `report`, `render`, `shouldReport`, and `renderForConsole` methods of your application's `App\Exceptions\Handler` class should accept instances of the `Throwable` interface instead of `Exception` instances. https://github.com/laravel/framework/pull/30610

- [x] Argument added

  - [x] The `resolveRouteBinding` method of the `Illuminate\Contracts\Routing\UrlRoutable` interface now accepts a `$field` argument. https://github.com/laravel/framework/pull/30471

- [x] Class rename

  - [x] The deprecated `Illuminate\Http\Resources\Json\Resource` class has been removed. https://github.com/laravel/framework/pull/30619

  - [x] The `Illuminate\Foundation\Testing\TestResponse` class has been renamed to `Illuminate\Testing\TestResponse`. The `Illuminate\Foundation\Testing\Assert` class has been renamed to `Illuminate\Testing\Assert`. https://github.com/laravel/framework/pull/31050