### PR TITLE
Add set for Laravel 8.x

### DIFF
--- a/config/sets/laravel80.php
+++ b/config/sets/laravel80.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 use Rector\Arguments\Rector\ClassMethod\ArgumentAdderRector;
 use Rector\Arguments\ValueObject\ArgumentAdder;
+use Rector\Laravel\Rector\ClassMethod\AddArgumentDefaultValueRector;
+use Rector\Laravel\Rector\ClassMethod\AddParentRegisterToEventServiceProviderRector;
+use Rector\Laravel\ValueObject\AddArgumentDefaultValue;
 use Rector\Renaming\Rector\MethodCall\RenameMethodRector;
 use Rector\Renaming\Rector\PropertyFetch\RenamePropertyRector;
 use Rector\Renaming\ValueObject\MethodCallRename;
@@ -31,7 +34,15 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         ]]);
 
     # https://github.com/laravel/framework/commit/46084d946cdcd1ae1f32fc87a4f1cc9e3a5bccf6
-    // TODO: Add default value to argument
+    $services->set(AddArgumentDefaultValueRector::class)
+        ->call('configure', [[
+            AddArgumentDefaultValueRector::ADDED_ARGUMENTS => ValueObjectInliner::inline([
+                new AddArgumentDefaultValue('Illuminate\Contracts\Events\Dispatcher', 'listen', 1, null),
+            ]),
+        ]]);
+
+    # https://github.com/laravel/framework/commit/f1289515b27e93248c09f04e3011bb7ce21b2737
+    $services->set(AddParentRegisterToEventServiceProviderRector::class);
 
     $services->set(RenamePropertyRector::class)
         ->call('configure', [[

--- a/config/sets/laravel80.php
+++ b/config/sets/laravel80.php
@@ -6,6 +6,7 @@ use Rector\Arguments\Rector\ClassMethod\ArgumentAdderRector;
 use Rector\Arguments\ValueObject\ArgumentAdder;
 use Rector\Laravel\Rector\ClassMethod\AddArgumentDefaultValueRector;
 use Rector\Laravel\Rector\ClassMethod\AddParentRegisterToEventServiceProviderRector;
+use Rector\Laravel\Rector\MethodCall\RemoveAllOnDispatchingMethodsWithJobChainingRector;
 use Rector\Laravel\ValueObject\AddArgumentDefaultValue;
 use Rector\Renaming\Rector\MethodCall\RenameMethodRector;
 use Rector\Renaming\Rector\PropertyFetch\RenamePropertyRector;
@@ -71,4 +72,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
                 new MethodCallRename('Illuminate\Testing\TestResponse', 'assertExactJson', 'assertSimilarJson'),
             ]),
         ]]);
+
+    # https://github.com/laravel/framework/commit/de662daf75207a8dd69565ed3630def74bc538d3
+    $services->set(RemoveAllOnDispatchingMethodsWithJobChainingRector::class);
 };

--- a/config/sets/laravel80.php
+++ b/config/sets/laravel80.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Arguments\Rector\ClassMethod\ArgumentAdderRector;
+use Rector\Arguments\ValueObject\ArgumentAdder;
+use Rector\Renaming\Rector\MethodCall\RenameMethodRector;
+use Rector\Renaming\Rector\PropertyFetch\RenamePropertyRector;
+use Rector\Renaming\ValueObject\MethodCallRename;
+use Rector\Renaming\ValueObject\RenameProperty;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Symplify\SymfonyPhpConfig\ValueObjectInliner;
+
+# see https://laravel.com/docs/8.x/upgrade
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $services = $containerConfigurator->services();
+
+    # https://github.com/laravel/framework/commit/4d228d6e9dbcbd4d97c45665980d8b8c685b27e6
+    $services->set(ArgumentAdderRector::class)
+        ->call('configure', [[
+            ArgumentAdderRector::ADDED_ARGUMENTS => ValueObjectInliner::inline([
+                new ArgumentAdder(
+                    'Illuminate\Contracts\Database\Eloquent\Castable',
+                    'castUsing',
+                    0,
+                    'arguments',
+                    [], // TODO: Add argument without default value
+                    'array'
+                ),
+            ]),
+        ]]);
+
+    # https://github.com/laravel/framework/commit/46084d946cdcd1ae1f32fc87a4f1cc9e3a5bccf6
+    // TODO: Add default value to argument
+
+    $services->set(RenamePropertyRector::class)
+        ->call('configure', [[
+            RenamePropertyRector::RENAMED_PROPERTIES => ValueObjectInliner::inline([
+                # https://github.com/laravel/framework/pull/32092/files
+                new RenameProperty('Illuminate\Support\Manager', 'app', 'container'),
+                # https://github.com/laravel/framework/commit/4656c2cf012ac62739ab5ea2bce006e1e9fe8f09
+                new RenameProperty('Illuminate\Contracts\Queue\ShouldQueue', 'retryAfter', 'backoff'),
+                # https://github.com/laravel/framework/commit/12c35e57c0a6da96f36ad77f88f083e96f927205
+                new RenameProperty('Illuminate\Contracts\Queue\ShouldQueue', 'timeoutAt', 'retryUntil'),
+            ]),
+        ]]);
+
+    $services->set(RenameMethodRector::class)
+        ->call('configure', [[
+            RenameMethodRector::METHOD_CALL_RENAMES => ValueObjectInliner::inline([
+                # https://github.com/laravel/framework/pull/32092/files
+                new MethodCallRename('Illuminate\Mail\PendingMail', 'sendNow', 'send'),
+                # https://github.com/laravel/framework/commit/4656c2cf012ac62739ab5ea2bce006e1e9fe8f09
+                new MethodCallRename('Illuminate\Contracts\Queue\ShouldQueue', 'retryAfter', 'backoff'),
+                # https://github.com/laravel/framework/commit/12c35e57c0a6da96f36ad77f88f083e96f927205
+                new MethodCallRename('Illuminate\Contracts\Queue\ShouldQueue', 'timeoutAt', 'retryUntil'),
+                # https://github.com/laravel/framework/commit/f9374fa5fb0450721fb2f90e96adef9d409b112c
+                new MethodCallRename('Illuminate\Testing\TestResponse', 'decodeResponseJson', 'json'),
+                # https://github.com/laravel/framework/commit/fd662d4699776a94e7ead2a42e82c340363fc5a6
+                new MethodCallRename('Illuminate\Testing\TestResponse', 'assertExactJson', 'assertSimilarJson'),
+            ]),
+        ]]);
+};

--- a/src/Rector/ClassMethod/AddArgumentDefaultValueRector.php
+++ b/src/Rector/ClassMethod/AddArgumentDefaultValueRector.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Laravel\Rector\ClassMethod;
+
+use PhpParser\BuilderHelpers;
+use PhpParser\Node;
+use PhpParser\Node\Param;
+use PhpParser\Node\Stmt\ClassMethod;
+use Rector\Core\Contract\Rector\ConfigurableRectorInterface;
+use Rector\Core\Rector\AbstractRector;
+use Rector\Laravel\ValueObject\AddArgumentDefaultValue;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+use Webmozart\Assert\Assert;
+
+/**
+ * @see \Rector\Laravel\Tests\Rector\ClassMethod\AddArgumentDefaultValueRector\AddArgumentDefaultValueRectorTest
+ */
+final class AddArgumentDefaultValueRector extends AbstractRector implements ConfigurableRectorInterface
+{
+    /**
+     * @var string
+     */
+    public const ADDED_ARGUMENTS = 'added_arguments';
+
+    /**
+     * @var AddArgumentDefaultValue[]
+     */
+    private array $addedArguments = [];
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Adds default value for arguments in defined methods.',
+            [
+                new ConfiguredCodeSample(
+                    <<<'CODE_SAMPLE'
+class SomeClass
+{
+    public function someMethod($value)
+    {
+    }
+}
+CODE_SAMPLE
+                    ,
+                    <<<'CODE_SAMPLE'
+class SomeClass
+{
+    public function someMethod($value = false)
+    {
+    }
+}
+CODE_SAMPLE
+                    ,
+                    [
+                        self::ADDED_ARGUMENTS => [
+                            new AddArgumentDefaultValue('SomeClass', 'someMethod', 0, false),
+                        ],
+                    ]
+                ),
+            ]
+        );
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [ClassMethod::class];
+    }
+
+    /**
+     * @param ClassMethod $node
+     */
+    public function refactor(Node $node): ClassMethod
+    {
+        foreach ($this->addedArguments as $addedArgument) {
+            if (! $this->nodeTypeResolver->isObjectType($node, $addedArgument->getObjectType())) {
+                continue;
+            }
+
+            if (! $this->isName($node->name, $addedArgument->getMethod())) {
+                continue;
+            }
+
+            if (! isset($node->params[$addedArgument->getPosition()])) {
+                continue;
+            }
+
+            $position = $addedArgument->getPosition();
+            $param = $node->params[$position];
+
+            if ($param->default !== null) {
+                continue;
+            }
+
+            $node->params[$position] = new Param($param->var, BuilderHelpers::normalizeValue(
+                $addedArgument->getDefaultValue()
+            ));
+        }
+
+        return $node;
+    }
+
+    /**
+     * @param array<string, AddArgumentDefaultValue[]> $configuration
+     */
+    public function configure(array $configuration): void
+    {
+        $addedArguments = $configuration[self::ADDED_ARGUMENTS] ?? [];
+        Assert::allIsInstanceOf($addedArguments, AddArgumentDefaultValue::class);
+        $this->addedArguments = $addedArguments;
+    }
+}

--- a/src/Rector/ClassMethod/AddParentRegisterToEventServiceProviderRector.php
+++ b/src/Rector/ClassMethod/AddParentRegisterToEventServiceProviderRector.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Laravel\Rector\ClassMethod;
+
+use PhpParser\Node;
+use PhpParser\Node\Stmt\ClassLike;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Expression;
+use PHPStan\Type\ObjectType;
+use Rector\Core\Rector\AbstractRector;
+use Rector\Nette\NodeAnalyzer\StaticCallAnalyzer;
+use Rector\NodeTypeResolver\Node\AttributeKey;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see https://laravel.com/docs/8.x/upgrade#the-event-service-provider-class
+ *
+ * @see \Rector\Laravel\Tests\Rector\ClassMethod\AddParentRegisterToEventServiceProviderRector\AddParentRegisterToEventServiceProviderRectorTest
+ */
+final class AddParentRegisterToEventServiceProviderRector extends AbstractRector
+{
+    /**
+     * @var string
+     */
+    private const REGISTER = 'register';
+
+    public function __construct(
+        private StaticCallAnalyzer $staticCallAnalyzer
+    ) {
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Add parent::register(); call to register() class method in child of Illuminate\Foundation\Support\Providers\EventServiceProvider',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
+
+class EventServiceProvider extends ServiceProvider
+{
+    public function register()
+    {
+    }
+}
+CODE_SAMPLE
+
+                    ,
+                    <<<'CODE_SAMPLE'
+use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
+
+class EventServiceProvider extends ServiceProvider
+{
+    public function register()
+    {
+        parent::register();
+    }
+}
+CODE_SAMPLE
+                ),
+            ]
+        );
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [ClassMethod::class];
+    }
+
+    /**
+     * @param ClassMethod $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        $classLike = $node->getAttribute(AttributeKey::CLASS_NODE);
+        if (! $classLike instanceof ClassLike) {
+            return null;
+        }
+
+        if (! $this->isObjectType(
+            $classLike,
+            new ObjectType('Illuminate\Foundation\Support\Providers\EventServiceProvider')
+        )) {
+            return null;
+        }
+
+        if (! $this->isName($node->name, self::REGISTER)) {
+            return null;
+        }
+
+        foreach ((array) $node->stmts as $key => $classMethodStmt) {
+            if ($classMethodStmt instanceof Expression) {
+                $classMethodStmt = $classMethodStmt->expr;
+            }
+
+            if (! $this->staticCallAnalyzer->isParentCallNamed($classMethodStmt, self::REGISTER)) {
+                continue;
+            }
+
+            if ($key === 0) {
+                return null;
+            }
+
+            unset($node->stmts[$key]);
+        }
+
+        $staticCall = $this->nodeFactory->createStaticCall('parent', self::REGISTER);
+        $parentStaticCallExpression = new Expression($staticCall);
+
+        $node->stmts = array_merge([$parentStaticCallExpression], (array) $node->stmts);
+
+        return $node;
+    }
+}

--- a/src/Rector/MethodCall/RemoveAllOnDispatchingMethodsWithJobChainingRector.php
+++ b/src/Rector/MethodCall/RemoveAllOnDispatchingMethodsWithJobChainingRector.php
@@ -12,6 +12,9 @@ use Rector\NodeTypeResolver\Node\AttributeKey;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
+/**
+ * @see \Rector\Laravel\Tests\Rector\MethodCall\RemoveAllOnDispatchingMethodsWithJobChainingRector\RemoveAllOnDispatchingMethodsWithJobChainingRectorTest
+ */
 class RemoveAllOnDispatchingMethodsWithJobChainingRector extends AbstractRector
 {
     /**

--- a/src/Rector/MethodCall/RemoveAllOnDispatchingMethodsWithJobChainingRector.php
+++ b/src/Rector/MethodCall/RemoveAllOnDispatchingMethodsWithJobChainingRector.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Laravel\Rector\MethodCall;
+
+use PhpParser\Node;
+use PHPStan\Type\ObjectType;
+use Rector\Core\Rector\AbstractRector;
+use Rector\Defluent\NodeAnalyzer\FluentChainMethodCallNodeAnalyzer;
+use Rector\NodeTypeResolver\Node\AttributeKey;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+class RemoveAllOnDispatchingMethodsWithJobChainingRector extends AbstractRector
+{
+    /**
+     * @var string
+     */
+    private const DISPATCH = 'dispatch';
+
+    private const SWAPPED_METHODS = [
+        'allOnQueue' => 'onQueue',
+        'allOnConnection' => 'onConnection',
+    ];
+
+    public function __construct(
+        private FluentChainMethodCallNodeAnalyzer $fluentChainMethodCallNodeAnalyzer
+    ) {
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Remove allOnQueue() and allOnConnection() methods used with job chaining, use the onQueue() and onConnection() methods instead.',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+Job::withChain([
+    new ChainJob(),
+])
+    ->dispatch()
+    ->allOnConnection('redis')
+    ->allOnQueue('podcasts');
+CODE_SAMPLE
+                    ,
+                    <<<'CODE_SAMPLE'
+Job::withChain([
+    new ChainJob(),
+])
+    ->onQueue('podcasts')
+    ->onConnection('redis')
+    ->dispatch();
+CODE_SAMPLE
+                ),
+            ]
+        );
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [Node\Expr\MethodCall::class];
+    }
+
+    /**
+     * @param \PhpParser\Node\Expr\MethodCall $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        if (! $this->isNames($node->name, array_keys(self::SWAPPED_METHODS))) {
+            return null;
+        }
+
+        $rootExpr = $this->fluentChainMethodCallNodeAnalyzer->resolveRootExpr($node);
+
+        if (! $this->isObjectType($rootExpr, new ObjectType('Illuminate\Foundation\Bus\Dispatchable'))) {
+            return null;
+        }
+
+        // Note that this change only affects code using the withChain method.
+        $callerNode = $rootExpr->getAttribute(AttributeKey::PARENT_NODE);
+        if (! $callerNode instanceof Node\Expr\StaticCall) {
+            return null;
+        }
+
+        if (! $this->isName($callerNode->name, 'withChain')) {
+            return null;
+        }
+
+        $names = $this->fluentChainMethodCallNodeAnalyzer->collectMethodCallNamesInChain($node);
+
+        if (! in_array(self::DISPATCH, $names, true)) {
+            return null;
+        }
+
+        // These methods should be called before calling the dispatch method.
+        $end = $node->var;
+        $current = $node->var;
+        while ($current instanceof Node\Expr\MethodCall) {
+            if ($this->isName($current->name, self::DISPATCH)) {
+                $var = $current->var;
+                $current->var = $node;
+                $node->name = new Node\Identifier(self::SWAPPED_METHODS[$this->getName($node->name)]);
+                $node->var = $var;
+                break;
+            }
+            $current = $current->var;
+        }
+
+        return $end;
+    }
+}

--- a/src/Set/LaravelSetList.php
+++ b/src/Set/LaravelSetList.php
@@ -71,6 +71,11 @@ final class LaravelSetList implements SetListInterface
     /**
      * @var string
      */
+    public const LARAVEL_80 = __DIR__ . '/../../config/sets/laravel80.php';
+
+    /**
+     * @var string
+     */
     public const LARAVEL_STATIC_TO_INJECTION = __DIR__ . '/../../config/sets/laravel-static-to-injection.php';
 
     /**

--- a/src/ValueObject/AddArgumentDefaultValue.php
+++ b/src/ValueObject/AddArgumentDefaultValue.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Laravel\ValueObject;
+
+use PHPStan\Type\ObjectType;
+
+class AddArgumentDefaultValue
+{
+    /**
+     * @param mixed $defaultValue
+     */
+    public function __construct(
+        private string $class,
+        private string $method,
+        private int $position,
+        private $defaultValue
+    ) {
+    }
+
+    public function getObjectType(): ObjectType
+    {
+        return new ObjectType($this->class);
+    }
+
+    public function getMethod(): string
+    {
+        return $this->method;
+    }
+
+    public function getPosition(): int
+    {
+        return $this->position;
+    }
+
+    public function getDefaultValue(): mixed
+    {
+        return $this->defaultValue;
+    }
+}

--- a/stubs/Illuminate/Contracts/Events/Dispatcher.php
+++ b/stubs/Illuminate/Contracts/Events/Dispatcher.php
@@ -1,0 +1,9 @@
+<?php
+namespace Illuminate\Contracts\Events;
+if (class_exists('Illuminate\Contracts\Events\Dispatcher')) {
+    return;
+}
+class Dispatcher
+{
+
+}

--- a/stubs/Illuminate/Foundation/Bus/Dispatchable.php
+++ b/stubs/Illuminate/Foundation/Bus/Dispatchable.php
@@ -1,0 +1,18 @@
+<?php
+namespace Illuminate\Foundation\Bus;
+
+if (class_exists('Illuminate\Foundation\Bus\Dispatchable')) {
+    return;
+}
+trait Dispatchable
+{
+    /**
+     * Set the jobs that should run if this job is successful.
+     *
+     * @param  array  $chain
+     * @return \Illuminate\Foundation\Bus\PendingChain
+     */
+    public static function withChain($chain)
+    {
+    }
+}

--- a/stubs/Illuminate/Foundation/Bus/PendingChain.php
+++ b/stubs/Illuminate/Foundation/Bus/PendingChain.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Illuminate\Foundation\Bus;
+if (class_exists('Illuminate\Foundation\Bus\PendingChain')) {
+    return;
+}
+class PendingChain
+{
+
+}

--- a/stubs/Illuminate/Foundation/Support/Providers/EventServiceProvider.php
+++ b/stubs/Illuminate/Foundation/Support/Providers/EventServiceProvider.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Illuminate\Foundation\Support\Providers;
+
+if (class_exists('Illuminate\Foundation\Support\Providers\EventServiceProvider')) {
+    return;
+}
+
+class EventServiceProvider
+{
+
+}

--- a/tests/Rector/ClassMethod/AddArgumentDefaultValueRector/AddArgumentDefaultValueRectorTest.php
+++ b/tests/Rector/ClassMethod/AddArgumentDefaultValueRector/AddArgumentDefaultValueRectorTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Laravel\Tests\Rector\ClassMethod\AddArgumentDefaultValueRector;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+final class AddArgumentDefaultValueRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(SmartFileInfo $fileInfo): void
+    {
+        $this->doTestFileInfo($fileInfo);
+    }
+
+    /**
+     * @return Iterator<SmartFileInfo>
+     */
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Rector/ClassMethod/AddArgumentDefaultValueRector/Fixture/fixture.php.inc
+++ b/tests/Rector/ClassMethod/AddArgumentDefaultValueRector/Fixture/fixture.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Rector\Laravel\Tests\Rector\ClassMethod\AddArgumentDefaultValueRector\Fixture;
+
+use Illuminate\Contracts\Events\Dispatcher;
+
+class Fixture extends Dispatcher
+{
+    public function listen($events, $listener)
+    {
+
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Laravel\Tests\Rector\ClassMethod\AddArgumentDefaultValueRector\Fixture;
+
+use Illuminate\Contracts\Events\Dispatcher;
+
+class Fixture extends Dispatcher
+{
+    public function listen($events, $listener = null)
+    {
+
+    }
+}
+
+?>

--- a/tests/Rector/ClassMethod/AddArgumentDefaultValueRector/Fixture/fixture2.php.inc
+++ b/tests/Rector/ClassMethod/AddArgumentDefaultValueRector/Fixture/fixture2.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Rector\Laravel\Tests\Rector\ClassMethod\AddArgumentDefaultValueRector\Fixture;
+
+use Illuminate\Contracts\Events\Dispatcher;
+
+class Fixture2 extends Dispatcher
+{
+    public function listen($events, $listener = null)
+    {
+
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Laravel\Tests\Rector\ClassMethod\AddArgumentDefaultValueRector\Fixture;
+
+use Illuminate\Contracts\Events\Dispatcher;
+
+class Fixture2 extends Dispatcher
+{
+    public function listen($events, $listener = null)
+    {
+
+    }
+}
+
+?>

--- a/tests/Rector/ClassMethod/AddArgumentDefaultValueRector/config/configured_rule.php
+++ b/tests/Rector/ClassMethod/AddArgumentDefaultValueRector/config/configured_rule.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Laravel\Rector\ClassMethod\AddArgumentDefaultValueRector;
+use Rector\Laravel\ValueObject\AddArgumentDefaultValue;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Symplify\SymfonyPhpConfig\ValueObjectInliner;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $containerConfigurator->import(__DIR__ . '/../../../../../config/config.php');
+
+    $services = $containerConfigurator->services();
+
+    $services->set(AddArgumentDefaultValueRector::class)
+        ->call('configure', [[
+            AddArgumentDefaultValueRector::ADDED_ARGUMENTS => ValueObjectInliner::inline([
+                new AddArgumentDefaultValue('Illuminate\Contracts\Events\Dispatcher', 'listen', 1, null),
+            ]),
+        ]]);
+};

--- a/tests/Rector/ClassMethod/AddParentRegisterToEventServiceProviderRector/AddParentRegisterToEventServiceProviderRectorTest.php
+++ b/tests/Rector/ClassMethod/AddParentRegisterToEventServiceProviderRector/AddParentRegisterToEventServiceProviderRectorTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Laravel\Tests\Rector\ClassMethod\AddParentRegisterToEventServiceProviderRector;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+final class AddParentRegisterToEventServiceProviderRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(SmartFileInfo $fileInfo): void
+    {
+        $this->doTestFileInfo($fileInfo);
+    }
+
+    /**
+     * @return Iterator<SmartFileInfo>
+     */
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Rector/ClassMethod/AddParentRegisterToEventServiceProviderRector/Fixture/fixture.php.inc
+++ b/tests/Rector/ClassMethod/AddParentRegisterToEventServiceProviderRector/Fixture/fixture.php.inc
@@ -1,0 +1,30 @@
+<?php
+
+namespace Rector\Laravel\Tests\Rector\ClassMethod\AddParentRegisterToEventServiceProviderRector\Fixture;
+
+use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
+
+class EventServiceProvider extends ServiceProvider
+{
+    public function register()
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Laravel\Tests\Rector\ClassMethod\AddParentRegisterToEventServiceProviderRector\Fixture;
+
+use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
+
+class EventServiceProvider extends ServiceProvider
+{
+    public function register()
+    {
+        parent::register();
+    }
+}
+
+?>

--- a/tests/Rector/ClassMethod/AddParentRegisterToEventServiceProviderRector/Fixture/on_the_last_line.php.inc
+++ b/tests/Rector/ClassMethod/AddParentRegisterToEventServiceProviderRector/Fixture/on_the_last_line.php.inc
@@ -1,0 +1,33 @@
+<?php
+
+namespace Rector\Laravel\Tests\Rector\ClassMethod\AddParentRegisterToEventServiceProviderRector\Fixture;
+
+use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
+
+class OnTheLastLine extends ServiceProvider
+{
+    public function register()
+    {
+        $value = 1000;
+        parent::register();
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Laravel\Tests\Rector\ClassMethod\AddParentRegisterToEventServiceProviderRector\Fixture;
+
+use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
+
+class OnTheLastLine extends ServiceProvider
+{
+    public function register()
+    {
+        parent::register();
+        $value = 1000;
+    }
+}
+
+?>

--- a/tests/Rector/ClassMethod/AddParentRegisterToEventServiceProviderRector/config/configured_rule.php
+++ b/tests/Rector/ClassMethod/AddParentRegisterToEventServiceProviderRector/config/configured_rule.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Laravel\Rector\ClassMethod\AddParentRegisterToEventServiceProviderRector;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $containerConfigurator->import(__DIR__ . '/../../../../../config/config.php');
+
+    $services = $containerConfigurator->services();
+
+    $services->set(AddParentRegisterToEventServiceProviderRector::class);
+};

--- a/tests/Rector/MethodCall/RemoveAllOnDispatchingMethodsWithJobChainingRector/Fixture/fixture.php.inc
+++ b/tests/Rector/MethodCall/RemoveAllOnDispatchingMethodsWithJobChainingRector/Fixture/fixture.php.inc
@@ -1,0 +1,59 @@
+<?php
+
+namespace Rector\Laravel\Tests\Rector\MethodCall\RemoveAllOnDispatchingMethodsWithJobChainingRector\Fixture;
+
+use Rector\Laravel\Tests\Rector\MethodCall\RemoveAllOnDispatchingMethodsWithJobChainingRector\Source\ChainJob;
+use Rector\Laravel\Tests\Rector\MethodCall\RemoveAllOnDispatchingMethodsWithJobChainingRector\Source\Job;
+
+class Fixture
+{
+    public function run()
+    {
+        Job::withChain([
+            new ChainJob(),
+        ])
+            ->dispatch()
+            ->allOnConnection('redis')
+            ->allOnQueue('podcasts');
+        Job::withChain([
+            new ChainJob(),
+        ])
+            ->someMethod()
+            ->dispatch()
+            ->someMethod2()
+            ->allOnConnection('redis')
+            ->allOnQueue('podcasts');
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Laravel\Tests\Rector\MethodCall\RemoveAllOnDispatchingMethodsWithJobChainingRector\Fixture;
+
+use Rector\Laravel\Tests\Rector\MethodCall\RemoveAllOnDispatchingMethodsWithJobChainingRector\Source\ChainJob;
+use Rector\Laravel\Tests\Rector\MethodCall\RemoveAllOnDispatchingMethodsWithJobChainingRector\Source\Job;
+
+class Fixture
+{
+    public function run()
+    {
+        Job::withChain([
+            new ChainJob(),
+        ])
+            ->onQueue('podcasts')
+            ->onConnection('redis')
+            ->dispatch();
+        Job::withChain([
+            new ChainJob(),
+        ])
+            ->someMethod()
+            ->onQueue('podcasts')
+            ->onConnection('redis')
+            ->dispatch()
+            ->someMethod2();
+    }
+}
+
+?>

--- a/tests/Rector/MethodCall/RemoveAllOnDispatchingMethodsWithJobChainingRector/RemoveAllOnDispatchingMethodsWithJobChainingRectorTest.php
+++ b/tests/Rector/MethodCall/RemoveAllOnDispatchingMethodsWithJobChainingRector/RemoveAllOnDispatchingMethodsWithJobChainingRectorTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Laravel\Tests\Rector\MethodCall\RemoveAllOnDispatchingMethodsWithJobChainingRector;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+final class RemoveAllOnDispatchingMethodsWithJobChainingRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(SmartFileInfo $fileInfo): void
+    {
+        $this->doTestFileInfo($fileInfo);
+    }
+
+    /**
+     * @return Iterator<SmartFileInfo>
+     */
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Rector/MethodCall/RemoveAllOnDispatchingMethodsWithJobChainingRector/Source/ChainJob.php
+++ b/tests/Rector/MethodCall/RemoveAllOnDispatchingMethodsWithJobChainingRector/Source/ChainJob.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Rector\Laravel\Tests\Rector\MethodCall\RemoveAllOnDispatchingMethodsWithJobChainingRector\Source;
+
+use Illuminate\Foundation\Bus\Dispatchable;
+
+class ChainJob
+{
+    use Dispatchable;
+}

--- a/tests/Rector/MethodCall/RemoveAllOnDispatchingMethodsWithJobChainingRector/Source/Job.php
+++ b/tests/Rector/MethodCall/RemoveAllOnDispatchingMethodsWithJobChainingRector/Source/Job.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Rector\Laravel\Tests\Rector\MethodCall\RemoveAllOnDispatchingMethodsWithJobChainingRector\Source;
+
+use Illuminate\Foundation\Bus\Dispatchable;
+
+class Job
+{
+    use Dispatchable;
+}

--- a/tests/Rector/MethodCall/RemoveAllOnDispatchingMethodsWithJobChainingRector/config/configured_rule.php
+++ b/tests/Rector/MethodCall/RemoveAllOnDispatchingMethodsWithJobChainingRector/config/configured_rule.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Laravel\Rector\MethodCall\RemoveAllOnDispatchingMethodsWithJobChainingRector;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $containerConfigurator->import(__DIR__ . '/../../../../../config/config.php');
+
+    $services = $containerConfigurator->services();
+
+    $services->set(RemoveAllOnDispatchingMethodsWithJobChainingRector::class);
+};


### PR DESCRIPTION
- [x] Add argument
  - [x] The `castUsing` method of the `Illuminate\Contracts\Database\Eloquent\Castable` interface has been updated to accept an array of arguments. https://github.com/laravel/framework/commit/4d228d6e9dbcbd4d97c45665980d8b8c685b27e6
- [x] Add default value
  - [x] The `listen` method of the `Illuminate\Contracts\Events\Dispatcher` contract has been updated to make the `$listener` property optional. https://github.com/laravel/framework/commit/46084d946cdcd1ae1f32fc87a4f1cc9e3a5bccf6
- [x] Rename property
  - [x] The previously deprecated `$app` property of the `Illuminate\Support\Manager` class has been removed. https://github.com/laravel/framework/pull/32092
  - [x] For consistency with other features of Laravel, the `retryAfter` method and `retryAfter` property of queued jobs, mailers, notifications, and listeners have been renamed to `backoff`. https://github.com/laravel/framework/commit/4656c2cf012ac62739ab5ea2bce006e1e9fe8f09
  - [x] The `timeoutAt` property of queued jobs, notifications, and listeners has been renamed to `retryUntil`. https://github.com/laravel/framework/commit/12c35e57c0a6da96f36ad77f88f083e96f927205
- [x] Rename method
  - [x] The previously deprecated `sendNow` method has been removed. Instead, please use the `send` method. https://github.com/laravel/framework/pull/32092
  - [x] For consistency with other features of Laravel, the `retryAfter` method and `retryAfter` property of queued jobs, mailers, notifications, and listeners have been renamed to `backoff`. https://github.com/laravel/framework/commit/4656c2cf012ac62739ab5ea2bce006e1e9fe8f09
  - [x] The `timeoutAt` property of queued jobs, notifications, and listeners has been renamed to `retryUntil`. https://github.com/laravel/framework/commit/12c35e57c0a6da96f36ad77f88f083e96f927205
  - [x] The `decodeResponseJson` method that belongs to the `Illuminate\Testing\TestResponse` class no longer accepts any arguments. https://github.com/laravel/framework/commit/f9374fa5fb0450721fb2f90e96adef9d409b112c
  - [x] The `assertExactJson` method now requires numeric keys of compared arrays to match and be in the same order. https://github.com/laravel/framework/commit/fd662d4699776a94e7ead2a42e82c340363fc5a6
- [x] If your `App\Providers\EventServiceProvider` class contains a register function, you should ensure that you call `parent::register` at the beginning of this method. https://github.com/laravel/framework/commit/f1289515b27e93248c09f04e3011bb7ce21b2737
- [x] For consistency with other dispatching methods, the `allOnQueue()` and `allOnConnection()` methods used with job chaining have been removed. You may use the `onQueue()` and `onConnection()` methods instead. https://github.com/laravel/framework/commit/de662daf75207a8dd69565ed3630def74bc538d3