### PR TITLE
Add RouteActionCallableRector

### DIFF
--- a/src/NodeFactory/RouterRegisterNodeAnalyzer.php
+++ b/src/NodeFactory/RouterRegisterNodeAnalyzer.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Laravel\NodeFactory;
+
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Identifier;
+use PHPStan\Type\ObjectType;
+use Rector\NodeNameResolver\NodeNameResolver;
+use Rector\NodeTypeResolver\NodeTypeResolver;
+
+final class RouterRegisterNodeAnalyzer
+{
+    public function __construct(
+        private NodeNameResolver $nodeNameResolver,
+        private NodeTypeResolver $nodeTypeResolver
+    ) {
+    }
+
+    public function isRegisterMethodStaticCall(MethodCall|StaticCall $node): bool
+    {
+        if (! $this->isRegisterName($node->name)) {
+            return false;
+        }
+
+        if ($node instanceof MethodCall && $this->nodeTypeResolver->isObjectTypes(
+            $node->var,
+            [new ObjectType('Illuminate\Routing\Router'), new ObjectType('Illuminate\Routing\RouteRegistrar')]
+        )) {
+            return true;
+        }
+
+        return $node instanceof StaticCall && $this->nodeNameResolver->isName(
+            $node->class,
+            'Illuminate\Support\Facades\Route'
+        );
+    }
+
+    public function isRegisterName(Identifier|Expr $name): bool
+    {
+        if ($this->isRegisterAnyVerb($name)) {
+            return true;
+        }
+
+        if ($this->isRegisterMultipleVerbs($name)) {
+            return true;
+        }
+
+        if ($this->isRegisterAllVerbs($name)) {
+            return true;
+        }
+
+        return $this->isRegisterFallback($name);
+    }
+
+    public function isRegisterMultipleVerbs(Identifier|Expr $name): bool
+    {
+        return $this->nodeNameResolver->isName($name, 'match');
+    }
+
+    public function isRegisterAllVerbs(Identifier|Expr $name): bool
+    {
+        return $this->nodeNameResolver->isName($name, 'any');
+    }
+
+    public function isRegisterAnyVerb(Identifier|Expr $name): bool
+    {
+        return $this->nodeNameResolver->isNames($name, ['delete', 'get', 'options', 'patch', 'post', 'put']);
+    }
+
+    public function isRegisterFallback(Identifier|Expr $name): bool
+    {
+        return $this->nodeNameResolver->isName($name, 'fallback');
+    }
+}

--- a/src/Rector/StaticCall/RouteActionCallableRector.php
+++ b/src/Rector/StaticCall/RouteActionCallableRector.php
@@ -103,7 +103,7 @@ CODE_SAMPLE
             return null;
         }
 
-        [$controller,$method] = $segments;
+        [$controller, $method] = $segments;
         $namespace = $this->getNamespace($this->file->getSmartFileInfo());
         if (! str_starts_with($controller, '\\')) {
             $controller = $namespace . '\\' . $controller;

--- a/src/Rector/StaticCall/RouteActionCallableRector.php
+++ b/src/Rector/StaticCall/RouteActionCallableRector.php
@@ -98,7 +98,12 @@ CODE_SAMPLE
             return null;
         }
 
-        [$controller, $method] = explode('@', $action);
+        $segments = explode('@', $action);
+        if (count($segments) !== 2) {
+            return null;
+        }
+
+        [$controller,$method] = $segments;
         $namespace = $this->getNamespace($this->file->getSmartFileInfo());
         if (! str_starts_with($controller, '\\')) {
             $controller = $namespace . '\\' . $controller;

--- a/src/Rector/StaticCall/RouteActionCallableRector.php
+++ b/src/Rector/StaticCall/RouteActionCallableRector.php
@@ -1,0 +1,179 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Laravel\Rector\StaticCall;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Identifier;
+use PHPStan\Reflection\Php\PhpMethodReflection;
+use PHPStan\Type\ObjectType;
+use Rector\Core\Contract\Rector\ConfigurableRectorInterface;
+use Rector\Core\Rector\AbstractRector;
+use Rector\Core\Reflection\ReflectionResolver;
+use Rector\NodeTypeResolver\Node\AttributeKey;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+/**
+ * @see https://laravel.com/docs/8.x/upgrade#automatic-controller-namespace-prefixing
+ *
+ * @see \Rector\Laravel\Tests\Rector\StaticCall\RouteActionCallableRector\RouteActionCallableRectorTest
+ */
+final class RouteActionCallableRector extends AbstractRector implements ConfigurableRectorInterface
+{
+    /**
+     * @var string
+     */
+    public const ROUTES = 'routes';
+
+    /**
+     * @var string
+     */
+    public const NAMESPACE = 'namespace';
+
+    private string $namespace = 'App\Http\Controllers';
+
+    /**
+     * @var array<string, string>
+     */
+    private array $routes = [];
+
+    public function __construct(
+        private ReflectionResolver $reflectionResolver,
+    ) {
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('Use PHP callable syntax instead of string syntax for controller route declarations.', [
+            new ConfiguredCodeSample(
+                <<<'CODE_SAMPLE'
+Route::get('/users', 'UserController@index');
+CODE_SAMPLE
+
+                ,
+                <<<'CODE_SAMPLE'
+Route::get('/users', [\App\Http\Controllers\UserController::class, 'index']);
+CODE_SAMPLE
+            ,
+                [
+                    self::NAMESPACE => 'App\Http\Controllers',
+                ]
+            ),
+        ]);
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [MethodCall::class, StaticCall::class];
+    }
+
+    /**
+     * @param Node\Expr\MethodCall|StaticCall $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        if (! $this->isRouteAdditionMethod($node)) {
+            return null;
+        }
+
+        $position = $this->getActionPosition($node->name);
+
+        if (! isset($node->args[$position])) {
+            return null;
+        }
+
+        $arg = $node->args[$position];
+
+        $action = $this->valueResolver->getValue($arg->value);
+        if (! $this->isActionString($action)) {
+            return null;
+        }
+
+        [$controller, $method] = explode('@', $action);
+        $namespace = $this->getNamespace($this->file->getSmartFileInfo());
+        if (! str_starts_with($controller, '\\')) {
+            $controller = $namespace . '\\' . $controller;
+        }
+
+        $scope = $node->getAttribute(AttributeKey::SCOPE);
+
+        $phpMethodReflection = $this->reflectionResolver->resolveMethodReflection($controller, $method, $scope);
+
+        if (! $phpMethodReflection instanceof PhpMethodReflection) {
+            return null;
+        }
+
+        $node->args[$position]->value = $this->nodeFactory->createArray([
+            $this->nodeFactory->createClassConstReference($controller),
+            $method,
+        ]);
+        return $node;
+    }
+
+    public function configure(array $configuration): void
+    {
+        $this->routes = $configuration[self::ROUTES] ?? [];
+        if (isset($configuration[self::NAMESPACE])) {
+            $this->namespace = $configuration[self::NAMESPACE];
+        }
+    }
+
+    private function isRouteAdditionMethod(MethodCall|StaticCall $node): bool
+    {
+        if (! $this->isNames(
+            $node->name,
+            ['any', 'delete', 'get', 'options', 'patch', 'post', 'put', 'match', 'fallback']
+        )) {
+            return false;
+        }
+
+        if ($node instanceof MethodCall && $this->nodeTypeResolver->isObjectTypes(
+            $node->var,
+            [new ObjectType('Illuminate\Routing\Router'), new ObjectType('Illuminate\Routing\RouteRegistrar')]
+        )) {
+            return true;
+        }
+
+        return $node instanceof StaticCall && $this->isName($node->class, 'Illuminate\Support\Facades\Route');
+    }
+
+    private function getActionPosition(Identifier|Expr $name): int
+    {
+        if ($this->isName($name, 'fallback')) {
+            return 0;
+        }
+
+        if ($this->isName($name, 'match')) {
+            return 2;
+        }
+
+        return 1;
+    }
+
+    /**
+     * @param mixed $action
+     */
+    private function isActionString($action): bool
+    {
+        if (! is_string($action)) {
+            return false;
+        }
+
+        return str_contains($action, '@');
+    }
+
+    private function getNamespace(SmartFileInfo $fileInfo): string
+    {
+        $realpath = $fileInfo->getRealPath();
+        return $this->routes[$realpath] ?? $this->namespace;
+    }
+}

--- a/stubs/Illuminate/Support/Facades/Route.php
+++ b/stubs/Illuminate/Support/Facades/Route.php
@@ -1,9 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Illuminate\Support\Facades;
+
 if (class_exists('\Illuminate\Support\Facades\Route')) {
     return;
 }
+
 /**
  * @method static \Illuminate\Routing\RouteRegistrar middleware(array|string|null $middleware)
  */

--- a/stubs/Illuminate/Support/Facades/Route.php
+++ b/stubs/Illuminate/Support/Facades/Route.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Illuminate\Support\Facades;
+if (class_exists('\Illuminate\Support\Facades\Route')) {
+    return;
+}
+/**
+ * @method static \Illuminate\Routing\RouteRegistrar middleware(array|string|null $middleware)
+ */
+class Route
+{
+}

--- a/tests/Rector/StaticCall/RouteActionCallableRector/Fixture/fixture.php.inc
+++ b/tests/Rector/StaticCall/RouteActionCallableRector/Fixture/fixture.php.inc
@@ -1,0 +1,39 @@
+<?php
+
+namespace Rector\Laravel\Tests\Rector\StaticCall\RouteActionCallableRector\Fixture;
+
+use Illuminate\Support\Facades\Route;
+
+Route::get('/users', 'SomeController@index');
+Route::get('/users', [\Rector\Laravel\Tests\Rector\StaticCall\RouteActionCallableRector\Source\SomeController::class, 'index']);
+Route::post('/users', 'SomeController@index');
+Route::patch('/users', 'SomeController@index');
+Route::put('/users', 'SomeController@index');
+Route::delete('/users', 'SomeController@index');
+Route::any('/users', 'SomeController@index');
+Route::match(['GET', 'POST'], '/users', 'SomeController@index');
+Route::fallback('SomeController@index');
+Route::options('/users', 'SomeController@index');
+Route::middleware([])->options('/users', 'SomeController@index');
+
+?>
+-----
+<?php
+
+namespace Rector\Laravel\Tests\Rector\StaticCall\RouteActionCallableRector\Fixture;
+
+use Illuminate\Support\Facades\Route;
+
+Route::get('/users', [\Rector\Laravel\Tests\Rector\StaticCall\RouteActionCallableRector\Source\SomeController::class, 'index']);
+Route::get('/users', [\Rector\Laravel\Tests\Rector\StaticCall\RouteActionCallableRector\Source\SomeController::class, 'index']);
+Route::post('/users', [\Rector\Laravel\Tests\Rector\StaticCall\RouteActionCallableRector\Source\SomeController::class, 'index']);
+Route::patch('/users', [\Rector\Laravel\Tests\Rector\StaticCall\RouteActionCallableRector\Source\SomeController::class, 'index']);
+Route::put('/users', [\Rector\Laravel\Tests\Rector\StaticCall\RouteActionCallableRector\Source\SomeController::class, 'index']);
+Route::delete('/users', [\Rector\Laravel\Tests\Rector\StaticCall\RouteActionCallableRector\Source\SomeController::class, 'index']);
+Route::any('/users', [\Rector\Laravel\Tests\Rector\StaticCall\RouteActionCallableRector\Source\SomeController::class, 'index']);
+Route::match(['GET', 'POST'], '/users', [\Rector\Laravel\Tests\Rector\StaticCall\RouteActionCallableRector\Source\SomeController::class, 'index']);
+Route::fallback([\Rector\Laravel\Tests\Rector\StaticCall\RouteActionCallableRector\Source\SomeController::class, 'index']);
+Route::options('/users', [\Rector\Laravel\Tests\Rector\StaticCall\RouteActionCallableRector\Source\SomeController::class, 'index']);
+Route::middleware([])->options('/users', [\Rector\Laravel\Tests\Rector\StaticCall\RouteActionCallableRector\Source\SomeController::class, 'index']);
+
+?>

--- a/tests/Rector/StaticCall/RouteActionCallableRector/Fixture/skip_method_not_exists.php.inc
+++ b/tests/Rector/StaticCall/RouteActionCallableRector/Fixture/skip_method_not_exists.php.inc
@@ -1,0 +1,21 @@
+<?php
+
+namespace Rector\Laravel\Tests\Rector\StaticCall\RouteActionCallableRector\Fixture;
+
+use Illuminate\Support\Facades\Route;
+
+Route::get('/users', 'SomeController@methodNotExists');
+Route::get('/users', 'SomeControllerNotExists@index');
+
+?>
+-----
+<?php
+
+namespace Rector\Laravel\Tests\Rector\StaticCall\RouteActionCallableRector\Fixture;
+
+use Illuminate\Support\Facades\Route;
+
+Route::get('/users', 'SomeController@methodNotExists');
+Route::get('/users', 'SomeControllerNotExists@index');
+
+?>

--- a/tests/Rector/StaticCall/RouteActionCallableRector/Fixture/skip_multiple_at.php.inc
+++ b/tests/Rector/StaticCall/RouteActionCallableRector/Fixture/skip_multiple_at.php.inc
@@ -1,0 +1,19 @@
+<?php
+
+namespace Rector\Laravel\Tests\Rector\StaticCall\RouteActionCallableRector\Fixture;
+
+use Illuminate\Support\Facades\Route;
+
+Route::get('/users', 'SomeController@index@bar');
+
+?>
+-----
+<?php
+
+namespace Rector\Laravel\Tests\Rector\StaticCall\RouteActionCallableRector\Fixture;
+
+use Illuminate\Support\Facades\Route;
+
+Route::get('/users', 'SomeController@index@bar');
+
+?>

--- a/tests/Rector/StaticCall/RouteActionCallableRector/RouteActionCallableRectorTest.php
+++ b/tests/Rector/StaticCall/RouteActionCallableRector/RouteActionCallableRectorTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Laravel\Tests\Rector\StaticCall\RouteActionCallableRector;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+final class RouteActionCallableRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(SmartFileInfo $fileInfo): void
+    {
+        $this->doTestFileInfo($fileInfo);
+    }
+
+    /**
+     * @return Iterator<SmartFileInfo>
+     */
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Rector/StaticCall/RouteActionCallableRector/Source/SomeController.php
+++ b/tests/Rector/StaticCall/RouteActionCallableRector/Source/SomeController.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rector\Laravel\Tests\Rector\StaticCall\RouteActionCallableRector\Source;
+
+class SomeController
+{
+    public function index()
+    {
+
+    }
+}

--- a/tests/Rector/StaticCall/RouteActionCallableRector/config/configured_rule.php
+++ b/tests/Rector/StaticCall/RouteActionCallableRector/config/configured_rule.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Laravel\Rector\StaticCall\RouteActionCallableRector;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $containerConfigurator->import(__DIR__ . '/../../../../../config/config.php');
+
+    $services = $containerConfigurator->services();
+
+    $services->set(RouteActionCallableRector::class)
+        ->call('configure', [[
+            RouteActionCallableRector::NAMESPACE => 'Rector\Laravel\Tests\Rector\StaticCall\RouteActionCallableRector\Source',
+        ]]);
+};


### PR DESCRIPTION
Use PHP callable syntax instead of string syntax for controller route declarations, which provides better support for jumping to the controller class in many IDEs.

```diff
use Illuminate\Support\Facades\Route;

-Route::get('/users', 'App\Http\Controllers\UserController@index');
+Route::get('/users', [\App\Http\Controllers\UserController::class, 'index']);
```