### PR TITLE
Add UnifyModelDatesWithCastsRector

### DIFF
--- a/config/sets/laravel57.php
+++ b/config/sets/laravel57.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use PHPStan\Type\ObjectType;
 use Rector\Arguments\Rector\ClassMethod\ArgumentAdderRector;
 use Rector\Arguments\ValueObject\ArgumentAdder;
 use Rector\Core\ValueObject\Visibility;
@@ -37,7 +38,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
                     0,
                     'request',
                     null,
-                    'Illuminate\Http\Illuminate\Http'
+                    new ObjectType('Illuminate\Http\Illuminate\Http')
                 ),
                 new ArgumentAdder(
                     'Illuminate\Foundation\Auth\SendsPasswordResetEmails',
@@ -45,7 +46,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
                     0,
                     'request',
                     null,
-                    'Illuminate\Http\Illuminate\Http'
+                    new ObjectType('Illuminate\Http\Illuminate\Http')
                 ),
                 new ArgumentAdder('Illuminate\Database\ConnectionInterface', 'select', 2, 'useReadPdo', true),
                 new ArgumentAdder('Illuminate\Database\ConnectionInterface', 'selectOne', 2, 'useReadPdo', true),

--- a/config/sets/laravel80.php
+++ b/config/sets/laravel80.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+use PHPStan\Type\ArrayType;
+use PHPStan\Type\MixedType;
 use Rector\Arguments\Rector\ClassMethod\ArgumentAdderRector;
 use Rector\Arguments\ValueObject\ArgumentAdder;
 use Rector\Laravel\Rector\ClassMethod\AddArgumentDefaultValueRector;
@@ -29,7 +31,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
                     0,
                     'arguments',
                     [], // TODO: Add argument without default value
-                    'array'
+                    new ArrayType(new MixedType(), new MixedType())
                 ),
             ]),
         ]]);

--- a/src/Rector/Class_/UnifyModelDatesWithCastsRector.php
+++ b/src/Rector/Class_/UnifyModelDatesWithCastsRector.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Laravel\Rector\Class_;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\Array_;
+use PhpParser\Node\Expr\ArrayItem;
+use PhpParser\Node\Scalar\String_;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\Property;
+use PHPStan\Type\ObjectType;
+use Rector\Core\NodeManipulator\ClassInsertManipulator;
+use Rector\Core\Rector\AbstractRector;
+use Symplify\Astral\ValueObject\NodeBuilder\PropertyBuilder;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see https://github.com/laravel/framework/pull/32856
+ *
+ * @see \Rector\Laravel\Tests\Rector\Class_\UnifyModelDatesWithCastsRector\UnifyModelDatesWithCastsRectorTest
+ */
+final class UnifyModelDatesWithCastsRector extends AbstractRector
+{
+    public function __construct(
+        private ClassInsertManipulator $classInsertManipulator
+    ) {
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('Unify Model $dates property with $casts', [
+            new CodeSample(
+                <<<'CODE_SAMPLE'
+use Illuminate\Database\Eloquent\Model;
+
+class Person extends Model
+{
+    protected $casts = [
+        'age' => 'integer',
+    ];
+
+    protected $dates = ['birthday'];
+}
+CODE_SAMPLE
+
+                ,
+                <<<'CODE_SAMPLE'
+use Illuminate\Database\Eloquent\Model;
+
+class Person extends Model
+{
+    protected $casts = [
+        'age' => 'integer', 'birthday' => 'datetime',
+    ];
+}
+CODE_SAMPLE
+            ),
+        ]);
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [Class_::class];
+    }
+
+    /**
+     * @param Class_ $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        if (! $this->isObjectType($node, new ObjectType('Illuminate\Database\Eloquent\Model'))) {
+            return null;
+        }
+
+        $datesProperty = $node->getProperty('dates');
+
+        if (! $datesProperty instanceof Property) {
+            return null;
+        }
+
+        $datesPropertyProperty = $datesProperty->props[0];
+        if (! $datesPropertyProperty->default instanceof Array_) {
+            return null;
+        }
+
+        $dates = $this->valueResolver->getValue($datesPropertyProperty->default);
+        if ($dates === []) {
+            return null;
+        }
+
+        $castsProperty = $node->getProperty('casts');
+
+        // add property $casts if not exists
+        if ($castsProperty === null) {
+            $castsProperty = $this->createCastsProperty();
+            $this->classInsertManipulator->addAsFirstMethod($node, $castsProperty);
+        }
+
+        $castsPropertyProperty = $castsProperty->props[0];
+        if (! $castsPropertyProperty->default instanceof Array_) {
+            return null;
+        }
+
+        $casts = $this->valueResolver->getValue($castsPropertyProperty->default);
+        // exclude attributes added in $casts
+        $missingDates = array_diff($dates, array_keys($casts));
+        foreach ($missingDates as $missingDate) {
+            $castsPropertyProperty->default->items[] = new ArrayItem(
+                new String_('datetime'),
+                new String_($missingDate)
+            );
+        }
+
+        $this->nodeRemover->removeNode($datesProperty);
+        return null;
+    }
+
+    private function createCastsProperty(): Property
+    {
+        $propertyBuilder = new PropertyBuilder('casts');
+        $propertyBuilder->makeProtected();
+        $propertyBuilder->setDefault([]);
+
+        $property = $propertyBuilder->getNode();
+
+        $this->phpDocInfoFactory->createFromNode($property);
+
+        return $property;
+    }
+}

--- a/tests/Rector/Class_/UnifyModelDatesWithCastsRector/Fixture/casts_property_not_exists.php.inc
+++ b/tests/Rector/Class_/UnifyModelDatesWithCastsRector/Fixture/casts_property_not_exists.php.inc
@@ -1,0 +1,25 @@
+<?php
+
+namespace Rector\Laravel\Tests\Rector\Class_\UnifyModelDatesWithCastsRector\Fixture;
+
+use Illuminate\Database\Eloquent\Model;
+
+class CastsPropertyNotExists extends Model
+{
+    protected $dates = ['birthday'];
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Laravel\Tests\Rector\Class_\UnifyModelDatesWithCastsRector\Fixture;
+
+use Illuminate\Database\Eloquent\Model;
+
+class CastsPropertyNotExists extends Model
+{
+    protected $casts = ['birthday' => 'datetime'];
+}
+
+?>

--- a/tests/Rector/Class_/UnifyModelDatesWithCastsRector/Fixture/dates_exists_in_casts.php.inc
+++ b/tests/Rector/Class_/UnifyModelDatesWithCastsRector/Fixture/dates_exists_in_casts.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Rector\Laravel\Tests\Rector\Class_\UnifyModelDatesWithCastsRector\Fixture;
+
+use Illuminate\Database\Eloquent\Model;
+
+class DatesExistsInCasts extends Model
+{
+    protected $casts = [
+        'birthday' => 'date:Y-m',
+    ];
+
+    protected $dates = ['birthday'];
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Laravel\Tests\Rector\Class_\UnifyModelDatesWithCastsRector\Fixture;
+
+use Illuminate\Database\Eloquent\Model;
+
+class DatesExistsInCasts extends Model
+{
+    protected $casts = [
+        'birthday' => 'date:Y-m',
+    ];
+}
+
+?>

--- a/tests/Rector/Class_/UnifyModelDatesWithCastsRector/Fixture/fixture.php.inc
+++ b/tests/Rector/Class_/UnifyModelDatesWithCastsRector/Fixture/fixture.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Rector\Laravel\Tests\Rector\Class_\UnifyModelDatesWithCastsRector\Fixture;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Fixture extends Model
+{
+    protected $casts = [
+        'age' => 'integer',
+    ];
+
+    protected $dates = ['birthday', 'created_at'];
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Laravel\Tests\Rector\Class_\UnifyModelDatesWithCastsRector\Fixture;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Fixture extends Model
+{
+    protected $casts = [
+        'age' => 'integer', 'birthday' => 'datetime', 'created_at' => 'datetime',
+    ];
+}
+
+?>

--- a/tests/Rector/Class_/UnifyModelDatesWithCastsRector/UnifyModelDatesWithCastsRectorTest.php
+++ b/tests/Rector/Class_/UnifyModelDatesWithCastsRector/UnifyModelDatesWithCastsRectorTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Laravel\Tests\Rector\Class_\UnifyModelDatesWithCastsRector;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+final class UnifyModelDatesWithCastsRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(SmartFileInfo $fileInfo): void
+    {
+        $this->doTestFileInfo($fileInfo);
+    }
+
+    /**
+     * @return Iterator<SmartFileInfo>
+     */
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Rector/Class_/UnifyModelDatesWithCastsRector/config/configured_rule.php
+++ b/tests/Rector/Class_/UnifyModelDatesWithCastsRector/config/configured_rule.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Laravel\Rector\Class_\UnifyModelDatesWithCastsRector;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $containerConfigurator->import(__DIR__ . '/../../../../../config/config.php');
+
+    $services = $containerConfigurator->services();
+    $services->set(UnifyModelDatesWithCastsRector::class);
+};


### PR DESCRIPTION
Ref: https://github.com/laravel/framework/pull/32856

Unifying `$dates` with `$casts` will remove ambiguity and give developers a single place for casting their _date_ attributes as well as other attributes. 

**Before**

```php
class Person extends Model
{
    protected $casts = [
        'age' => 'integer',
    ];

    protected $dates = ['birthday'];
}
```

**After**

```php
class Person extends Model
{
    protected $casts = [
        'age' => 'integer',
        'birthday' => 'datetime',
    ];
}
```