### PR TITLE
Add AnonymousMigrationsRector

### DIFF
--- a/src/Rector/Class_/AnonymousMigrationsRector.php
+++ b/src/Rector/Class_/AnonymousMigrationsRector.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Laravel\Rector\Class_;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\New_;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\Return_;
+use PHPStan\Type\ObjectType;
+use Rector\Core\NodeAnalyzer\ClassAnalyzer;
+use Rector\Core\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see https://github.com/laravel/framework/pull/36906
+ *
+ * @see \Rector\Laravel\Tests\Rector\Class_\AnonymousMigrationsRector\AnonymousMigrationsRectorTest
+ */
+final class AnonymousMigrationsRector extends AbstractRector
+{
+    public function __construct(
+        private ClassAnalyzer $classAnalyzer
+    ) {
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('Convert migrations to anonymous classes.', [
+            new CodeSample(
+                <<<'CODE_SAMPLE'
+use Illuminate\Database\Migrations\Migration;
+
+class CreateUsersTable extends Migration
+{
+    // ...
+}
+CODE_SAMPLE
+
+                ,
+                <<<'CODE_SAMPLE'
+use Illuminate\Database\Migrations\Migration;
+
+return new class extends Migration
+{
+    // ...
+};
+CODE_SAMPLE
+            ),
+        ]);
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [Class_::class];
+    }
+
+    /**
+     * @param Class_ $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        if (! $this->isObjectType($node, new ObjectType('Illuminate\Database\Migrations\Migration'))) {
+            return null;
+        }
+
+        if ($this->classAnalyzer->isAnonymousClass($node)) {
+            return null;
+        }
+
+        return new Return_(new New_(new Class_(null, [
+            'flags' => $node->flags,
+            'extends' => $node->extends,
+            'implements' => $node->implements,
+            'stmts' => $node->stmts,
+            'attrGroups' => $node->attrGroups,
+        ])));
+    }
+}

--- a/src/Rector/Class_/AnonymousMigrationsRector.php
+++ b/src/Rector/Class_/AnonymousMigrationsRector.php
@@ -16,6 +16,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
 /**
  * @see https://github.com/laravel/framework/pull/36906
+ * @see https://github.com/laravel/framework/pull/37352
  *
  * @see \Rector\Laravel\Tests\Rector\Class_\AnonymousMigrationsRector\AnonymousMigrationsRectorTest
  */

--- a/stubs/Illuminate/Database/Migrations/Migration.php
+++ b/stubs/Illuminate/Database/Migrations/Migration.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Illuminate\Database\Migrations;
+
+if (class_exists('Illuminate\Database\Migrations\Migration')) {
+    return;
+}
+
+class Migration
+{
+}

--- a/tests/Rector/Class_/AnonymousMigrationsRector/AnonymousMigrationsRectorTest.php
+++ b/tests/Rector/Class_/AnonymousMigrationsRector/AnonymousMigrationsRectorTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Laravel\Tests\Rector\Class_\AnonymousMigrationsRector;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+final class AnonymousMigrationsRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(SmartFileInfo $fileInfo): void
+    {
+        $this->doTestFileInfo($fileInfo);
+    }
+
+    /**
+     * @return Iterator<SmartFileInfo>
+     */
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Rector/Class_/AnonymousMigrationsRector/Fixture/fixture.php.inc
+++ b/tests/Rector/Class_/AnonymousMigrationsRector/Fixture/fixture.php.inc
@@ -1,0 +1,25 @@
+<?php
+
+namespace Rector\Laravel\Tests\Rector\Class_\AnonymousMigrationsRector\Fixture;
+
+use Illuminate\Database\Migrations\Migration;
+
+class CreateUsersTable extends Migration
+{
+    // ...
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Laravel\Tests\Rector\Class_\AnonymousMigrationsRector\Fixture;
+
+use Illuminate\Database\Migrations\Migration;
+
+return new class extends Migration
+{
+    // ...
+};
+
+?>

--- a/tests/Rector/Class_/AnonymousMigrationsRector/Fixture/skip_anonymous_migration.php.inc
+++ b/tests/Rector/Class_/AnonymousMigrationsRector/Fixture/skip_anonymous_migration.php.inc
@@ -1,0 +1,10 @@
+<?php
+
+namespace Rector\Laravel\Tests\Rector\Class_\AnonymousMigrationsRector\Fixture;
+
+use Illuminate\Database\Migrations\Migration;
+
+return new class extends Migration
+{
+    // ...
+};

--- a/tests/Rector/Class_/AnonymousMigrationsRector/config/configured_rule.php
+++ b/tests/Rector/Class_/AnonymousMigrationsRector/config/configured_rule.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Laravel\Rector\Class_\AnonymousMigrationsRector;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $containerConfigurator->import(__DIR__ . '/../../../../../config/config.php');
+
+    $services = $containerConfigurator->services();
+    $services->set(AnonymousMigrationsRector::class);
+};


### PR DESCRIPTION
Convert migrations to anonymous classes to prevent duplication of class names. 
Ref: https://github.com/laravel/framework/pull/36906, https://github.com/laravel/framework/pull/37352

```diff
 use Illuminate\Database\Migrations\Migration;

-class CreateUsersTable extends Migration
+return new class extends Migration
 {
     // ...
-}
+};
```