### PR TITLE
Added renaming of database assertions not listed in the 5.4 Upgrade Guide

### DIFF
--- a/config/sets/laravel54.php
+++ b/config/sets/laravel54.php
@@ -64,6 +64,12 @@ return static function (ContainerConfigurator $containerConfigurator): void {
                 new MethodCallRename('Illuminate\Routing\UrlGenerator', 'forceSchema', 'forceScheme'),
                 new MethodCallRename('Illuminate\Validation\Validator', 'addError', 'addFailure'),
                 new MethodCallRename('Illuminate\Validation\Validator', 'doReplacements', 'makeReplacements'),
+
+                # https://github.com/laravel/framework/commit/f23ac640fa403ca8d4131c36367b53e123b6b852
+                new MethodCallRename('Illuminate\Foundation\Testing\Concerns\InteractsWithDatabase', 'seeInDatabase', 'assertDatabaseHas'),
+                new MethodCallRename('Illuminate\Foundation\Testing\Concerns\InteractsWithDatabase', 'missingFromDatabase', 'assertDatabaseMissing'),
+                new MethodCallRename('Illuminate\Foundation\Testing\Concerns\InteractsWithDatabase', 'dontSeeInDatabase', 'assertDatabaseMissing'),
+                new MethodCallRename('Illuminate\Foundation\Testing\Concerns\InteractsWithDatabase', 'notSeeInDatabase', 'assertDatabaseMissing'),
             ]),
         ]]);
 };

--- a/config/sets/laravel54.php
+++ b/config/sets/laravel54.php
@@ -66,10 +66,26 @@ return static function (ContainerConfigurator $containerConfigurator): void {
                 new MethodCallRename('Illuminate\Validation\Validator', 'doReplacements', 'makeReplacements'),
 
                 # https://github.com/laravel/framework/commit/f23ac640fa403ca8d4131c36367b53e123b6b852
-                new MethodCallRename('Illuminate\Foundation\Testing\Concerns\InteractsWithDatabase', 'seeInDatabase', 'assertDatabaseHas'),
-                new MethodCallRename('Illuminate\Foundation\Testing\Concerns\InteractsWithDatabase', 'missingFromDatabase', 'assertDatabaseMissing'),
-                new MethodCallRename('Illuminate\Foundation\Testing\Concerns\InteractsWithDatabase', 'dontSeeInDatabase', 'assertDatabaseMissing'),
-                new MethodCallRename('Illuminate\Foundation\Testing\Concerns\InteractsWithDatabase', 'notSeeInDatabase', 'assertDatabaseMissing'),
+                new MethodCallRename(
+                    'Illuminate\Foundation\Testing\Concerns\InteractsWithDatabase',
+                    'seeInDatabase',
+                    'assertDatabaseHas'
+                ),
+                new MethodCallRename(
+                    'Illuminate\Foundation\Testing\Concerns\InteractsWithDatabase',
+                    'missingFromDatabase',
+                    'assertDatabaseMissing'
+                ),
+                new MethodCallRename(
+                    'Illuminate\Foundation\Testing\Concerns\InteractsWithDatabase',
+                    'dontSeeInDatabase',
+                    'assertDatabaseMissing'
+                ),
+                new MethodCallRename(
+                    'Illuminate\Foundation\Testing\Concerns\InteractsWithDatabase',
+                    'notSeeInDatabase',
+                    'assertDatabaseMissing'
+                ),
             ]),
         ]]);
 };


### PR DESCRIPTION
Ref: https://github.com/laravel/framework/commit/f23ac640fa403ca8d4131c36367b53e123b6b852