### PR TITLE
Add AddGenericReturnTypeToRelationsRector

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
         "check-cs": "vendor/bin/ecs check --ansi",
         "fix-cs": "vendor/bin/ecs check --fix --ansi",
         "docs": [
-            "vendor/bin/rule-doc-generator generate src --output-file docs/rector_rules_overview.md --ansi",
+            "vendor/bin/rule-doc-generator generate src --output-file docs/rector_rules_overview.md --ansi --configure-method",
             "vendor/bin/ecs check-markdown docs/rector_rules_overview.md --ansi --fix"
         ]
     },

--- a/docs/rector_rules_overview.md
+++ b/docs/rector_rules_overview.md
@@ -1,4 +1,4 @@
-# 20 Rules Overview
+# 21 Rules Overview
 
 ## AddArgumentDefaultValueRector
 
@@ -12,14 +12,16 @@ Adds default value for arguments in defined methods.
 use Rector\Laravel\Rector\ClassMethod\AddArgumentDefaultValueRector;
 use Rector\Laravel\ValueObject\AddArgumentDefaultValue;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
-use Symplify\SymfonyPhpConfig\ValueObjectInliner;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
     $services->set(AddArgumentDefaultValueRector::class)
-->configure([                new AddArgumentDefaultValue('SomeClass', 'someMethod', 0, false),
-]);
+        ->configure([
+            AddArgumentDefaultValueRector::ADDED_ARGUMENTS => [
+                new AddArgumentDefaultValue('SomeClass', 'someMethod', 0, false),
+            ],
+        ]);
 };
 ```
 
@@ -31,6 +33,29 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 -    public function someMethod($value)
 +    public function someMethod($value = false)
      {
+     }
+ }
+```
+
+<br>
+
+## AddGenericReturnTypeToRelationsRector
+
+Add generic return type to relations in child of `Illuminate\Database\Eloquent\Model`
+
+- class: [`Rector\Laravel\Rector\ClassMethod\AddGenericReturnTypeToRelationsRector`](../src/Rector/ClassMethod/AddGenericReturnTypeToRelationsRector.php)
+
+```diff
+ use App\Account;
+ use Illuminate\Database\Eloquent\Model;
+ use Illuminate\Database\Eloquent\Relations\HasMany;
+
+ class User extends Model
+ {
++    /** @return HasMany<Account> */
+     public function accounts(): HasMany
+     {
+         return $this->hasMany(Account::class);
      }
  }
 ```
@@ -307,9 +332,9 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
     $services->set(OptionalToNullsafeOperatorRector::class)
-        ->call('configure', [[
+        ->configure([
             OptionalToNullsafeOperatorRector::EXCLUDE_METHODS => ['present'],
-        ]]);
+        ]);
 };
 ```
 
@@ -425,9 +450,9 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
     $services->set(RouteActionCallableRector::class)
-        ->call('configure', [[
+        ->configure([
             RouteActionCallableRector::NAMESPACE => 'App\Http\Controllers',
-        ]]);
+        ]);
 };
 ```
 

--- a/src/Rector/ClassMethod/AddGenericReturnTypeToRelationsRector.php
+++ b/src/Rector/ClassMethod/AddGenericReturnTypeToRelationsRector.php
@@ -1,0 +1,207 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Laravel\Rector\ClassMethod;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\ClassLike;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Return_;
+use PHPStan\PhpDocParser\Ast\PhpDoc\ReturnTagValueNode;
+use PHPStan\PhpDocParser\Ast\Type\GenericTypeNode;
+use PHPStan\Type\Constant\ConstantStringType;
+use PHPStan\Type\Generic\GenericClassStringType;
+use PHPStan\Type\ObjectType;
+use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
+use Rector\BetterPhpDocParser\ValueObject\Type\FullyQualifiedIdentifierTypeNode;
+use Rector\Core\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/** @see \Rector\Laravel\Tests\Rector\ClassMethod\AddGenericReturnTypeToRelationsRector\AddGenericReturnTypeToRelationsRectorTest */
+class AddGenericReturnTypeToRelationsRector extends AbstractRector
+{
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Add generic return type to relations in child of Illuminate\Database\Eloquent\Model',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+use App\Account;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class User extends Model
+{
+    public function accounts(): HasMany
+    {
+        return $this->hasMany(Account::class);
+    }
+}
+CODE_SAMPLE
+
+                    ,
+                    <<<'CODE_SAMPLE'
+use App\Account;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class User extends Model
+{
+    /** @return HasMany<Account> */
+    public function accounts(): HasMany
+    {
+        return $this->hasMany(Account::class);
+    }
+}
+CODE_SAMPLE
+                ),
+            ]
+        );
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [ClassMethod::class];
+    }
+
+    /**
+     * @param ClassMethod $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        if ($this->shouldSkipNode($node)) {
+            return null;
+        }
+
+        $methodReturnType = $node->getReturnType();
+
+        if ($methodReturnType === null) {
+            return null;
+        }
+
+        $methodReturnTypeName = $this->getName($methodReturnType);
+
+        if ($methodReturnTypeName === null) {
+            return null;
+        }
+
+        if (! $this->isObjectType(
+            $methodReturnType,
+            new ObjectType('Illuminate\Database\Eloquent\Relations\Relation')
+        )) {
+            return null;
+        }
+
+        $docInfo = $this->phpDocInfoFactory->createFromNode($node);
+        if (! $docInfo instanceof PhpDocInfo) {
+            return null;
+        }
+
+        // Return, if already has return type
+        if ($node->getDocComment() !== null && $docInfo->hasByName('return')) {
+            return null;
+        }
+
+        $returnStatement = $this->betterNodeFinder->findFirstInFunctionLikeScoped(
+            $node,
+            fn (Node $subNode): bool => $subNode instanceof Return_
+        );
+
+        if (! $returnStatement instanceof Return_) {
+            return null;
+        }
+
+        $relationMethodCall = $this->betterNodeFinder->findFirstInstanceOf($returnStatement, MethodCall::class);
+
+        if (! $relationMethodCall instanceof MethodCall) {
+            return null;
+        }
+
+        $relatedClass = $this->getRelatedModelClassFromMethodCall($relationMethodCall);
+
+        if ($relatedClass === null) {
+            return null;
+        }
+
+        $docInfo->addTagValueNode(
+            new ReturnTagValueNode(
+                new GenericTypeNode(
+                    new FullyQualifiedIdentifierTypeNode($methodReturnTypeName),
+                    [new FullyQualifiedIdentifierTypeNode($relatedClass)],
+                ),
+                ''
+            )
+        );
+
+        return $node;
+    }
+
+    private function getRelatedModelClassFromMethodCall(MethodCall $methodCall): ?string
+    {
+        $methodName = $methodCall->name;
+
+        if (! $methodName instanceof Identifier) {
+            return null;
+        }
+
+        // Called method should be one of the Laravel's relation methods
+        if (! in_array($methodName->name, [
+            'hasOne', 'hasOneThrough', 'morphOne',
+            'belongsTo', 'morphTo',
+            'hasMany', 'hasManyThrough', 'morphMany',
+            'belongsToMany', 'morphToMany', 'morphedByMany',
+        ], true)) {
+            return null;
+        }
+
+        if (count($methodCall->getArgs()) < 1) {
+            return null;
+        }
+
+        $argType = $this->getType($methodCall->getArgs()[0]->value);
+
+        if ($argType instanceof ConstantStringType) {
+            return $argType->getValue();
+        }
+
+        if (! $argType instanceof GenericClassStringType) {
+            return null;
+        }
+
+        $modelType = $argType->getGenericType();
+
+        if (! $modelType instanceof ObjectType) {
+            return null;
+        }
+
+        return $modelType->getClassName();
+    }
+
+    private function shouldSkipNode(ClassMethod $node): bool
+    {
+        if ($node->stmts === null) {
+            return true;
+        }
+
+        $classLike = $this->betterNodeFinder->findParentType($node, ClassLike::class);
+
+        if (! $classLike instanceof ClassLike) {
+            return true;
+        }
+
+        if ($classLike instanceof Class_) {
+            return ! $this->isObjectType($classLike, new ObjectType('Illuminate\Database\Eloquent\Model'));
+        }
+
+        return false;
+    }
+}

--- a/stubs/Illuminate/Database/Eloquent/Relations/HasMany.php
+++ b/stubs/Illuminate/Database/Eloquent/Relations/HasMany.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Relations;
+
+if (class_exists('Illuminate\Database\Eloquent\Relations\HasMany')) {
+    return;
+}
+
+class HasMany extends Relation
+{
+}

--- a/stubs/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/stubs/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Relations;
+
+if (class_exists('Illuminate\Database\Eloquent\Relations\Relation')) {
+    return;
+}
+
+abstract class Relation
+{
+}

--- a/tests/Rector/ClassMethod/AddGenericReturnTypeToRelationsRector/AddGenericReturnTypeToRelationsRectorTest.php
+++ b/tests/Rector/ClassMethod/AddGenericReturnTypeToRelationsRector/AddGenericReturnTypeToRelationsRectorTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Laravel\Tests\Rector\ClassMethod\AddGenericReturnTypeToRelationsRector;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+final class AddGenericReturnTypeToRelationsRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(SmartFileInfo $fileInfo): void
+    {
+        $this->doTestFileInfo($fileInfo);
+    }
+
+    /**
+     * @return Iterator<SmartFileInfo>
+     */
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Rector/ClassMethod/AddGenericReturnTypeToRelationsRector/Fixture/empty-phpdoc.php.inc
+++ b/tests/Rector/ClassMethod/AddGenericReturnTypeToRelationsRector/Fixture/empty-phpdoc.php.inc
@@ -1,0 +1,42 @@
+<?php
+
+namespace Rector\Laravel\Tests\Rector\ClassMethod\AddGenericReturnTypeToRelationsRector\Fixture;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class Account extends Model {}
+
+class User extends Model
+{
+    /**
+     */
+    public function accounts(): HasMany
+    {
+        return $this->hasMany(Account::class);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Laravel\Tests\Rector\ClassMethod\AddGenericReturnTypeToRelationsRector\Fixture;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class Account extends Model {}
+
+class User extends Model
+{
+    /**
+     * @return \Illuminate\Database\Eloquent\Relations\HasMany<\Rector\Laravel\Tests\Rector\ClassMethod\AddGenericReturnTypeToRelationsRector\Fixture\Account>
+     */
+    public function accounts(): HasMany
+    {
+        return $this->hasMany(Account::class);
+    }
+}
+
+?>

--- a/tests/Rector/ClassMethod/AddGenericReturnTypeToRelationsRector/Fixture/no-phpdoc.php.inc
+++ b/tests/Rector/ClassMethod/AddGenericReturnTypeToRelationsRector/Fixture/no-phpdoc.php.inc
@@ -1,0 +1,40 @@
+<?php
+
+namespace Rector\Laravel\Tests\Rector\ClassMethod\AddGenericReturnTypeToRelationsRector\Fixture;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class Account extends Model {}
+
+class User extends Model
+{
+    public function accounts(): HasMany
+    {
+        return $this->hasMany(Account::class);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Laravel\Tests\Rector\ClassMethod\AddGenericReturnTypeToRelationsRector\Fixture;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class Account extends Model {}
+
+class User extends Model
+{
+    /**
+     * @return \Illuminate\Database\Eloquent\Relations\HasMany<\Rector\Laravel\Tests\Rector\ClassMethod\AddGenericReturnTypeToRelationsRector\Fixture\Account>
+     */
+    public function accounts(): HasMany
+    {
+        return $this->hasMany(Account::class);
+    }
+}
+
+?>

--- a/tests/Rector/ClassMethod/AddGenericReturnTypeToRelationsRector/Fixture/phpdoc-with-existing-return.php.inc
+++ b/tests/Rector/ClassMethod/AddGenericReturnTypeToRelationsRector/Fixture/phpdoc-with-existing-return.php.inc
@@ -1,0 +1,43 @@
+<?php
+
+namespace Rector\Laravel\Tests\Rector\ClassMethod\AddGenericReturnTypeToRelationsRector\Fixture;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class Account extends Model {}
+
+class User extends Model
+{
+    /**
+     * @return int
+     */
+    public function accounts(): HasMany
+    {
+        return $this->hasMany(Account::class);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Laravel\Tests\Rector\ClassMethod\AddGenericReturnTypeToRelationsRector\Fixture;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class Account extends Model {}
+
+class User extends Model
+{
+    /**
+     * @return int
+     */
+    public function accounts(): HasMany
+    {
+        return $this->hasMany(Account::class);
+    }
+}
+
+?>

--- a/tests/Rector/ClassMethod/AddGenericReturnTypeToRelationsRector/Fixture/phpdoc-without-return.php.inc
+++ b/tests/Rector/ClassMethod/AddGenericReturnTypeToRelationsRector/Fixture/phpdoc-without-return.php.inc
@@ -1,0 +1,44 @@
+<?php
+
+namespace Rector\Laravel\Tests\Rector\ClassMethod\AddGenericReturnTypeToRelationsRector\Fixture;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class Account extends Model {}
+
+class User extends Model
+{
+    /**
+     * This is a dummy comment about this method.
+     */
+    public function accounts(): HasMany
+    {
+        return $this->hasMany(Account::class);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Laravel\Tests\Rector\ClassMethod\AddGenericReturnTypeToRelationsRector\Fixture;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class Account extends Model {}
+
+class User extends Model
+{
+    /**
+     * This is a dummy comment about this method.
+     * @return \Illuminate\Database\Eloquent\Relations\HasMany<\Rector\Laravel\Tests\Rector\ClassMethod\AddGenericReturnTypeToRelationsRector\Fixture\Account>
+     */
+    public function accounts(): HasMany
+    {
+        return $this->hasMany(Account::class);
+    }
+}
+
+?>

--- a/tests/Rector/ClassMethod/AddGenericReturnTypeToRelationsRector/Fixture/relation-in-trait.php.inc
+++ b/tests/Rector/ClassMethod/AddGenericReturnTypeToRelationsRector/Fixture/relation-in-trait.php.inc
@@ -1,0 +1,50 @@
+<?php
+
+namespace Rector\Laravel\Tests\Rector\ClassMethod\AddGenericReturnTypeToRelationsRector\Fixture;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class Account extends Model {}
+
+trait AccountTrait
+{
+    public function accounts(): HasMany
+    {
+        return $this->hasMany(Account::class);
+    }
+}
+
+class User extends Model
+{
+    use AccountTrait;
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Laravel\Tests\Rector\ClassMethod\AddGenericReturnTypeToRelationsRector\Fixture;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class Account extends Model {}
+
+trait AccountTrait
+{
+    /**
+     * @return \Illuminate\Database\Eloquent\Relations\HasMany<\Rector\Laravel\Tests\Rector\ClassMethod\AddGenericReturnTypeToRelationsRector\Fixture\Account>
+     */
+    public function accounts(): HasMany
+    {
+        return $this->hasMany(Account::class);
+    }
+}
+
+class User extends Model
+{
+    use AccountTrait;
+}
+
+?>

--- a/tests/Rector/ClassMethod/AddGenericReturnTypeToRelationsRector/Fixture/relation-without-return-type.php.inc
+++ b/tests/Rector/ClassMethod/AddGenericReturnTypeToRelationsRector/Fixture/relation-without-return-type.php.inc
@@ -1,0 +1,37 @@
+<?php
+
+namespace Rector\Laravel\Tests\Rector\ClassMethod\AddGenericReturnTypeToRelationsRector\Fixture;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class Account extends Model {}
+
+class User extends Model
+{
+    public function accounts()
+    {
+        return $this->hasMany(Account::class);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Laravel\Tests\Rector\ClassMethod\AddGenericReturnTypeToRelationsRector\Fixture;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class Account extends Model {}
+
+class User extends Model
+{
+    public function accounts()
+    {
+        return $this->hasMany(Account::class);
+    }
+}
+
+?>

--- a/tests/Rector/ClassMethod/AddGenericReturnTypeToRelationsRector/config/configured_rule.php
+++ b/tests/Rector/ClassMethod/AddGenericReturnTypeToRelationsRector/config/configured_rule.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Laravel\Rector\ClassMethod\AddGenericReturnTypeToRelationsRector;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $containerConfigurator->import(__DIR__ . '/../../../../../config/config.php');
+
+    $services = $containerConfigurator->services();
+
+    $services->set(AddGenericReturnTypeToRelationsRector::class);
+};


### PR DESCRIPTION
This PR adds a new rector called `AddGenericReturnTypeToRelationsRector` Which adds generic return type docblocks to Laravel relations in models.

Laravel relations are not generic. But Larastan (PHPStan extension for Laravel) makes them generic to be able to do more accurate analysis on relations. So this rector is not really useful for normal Laravel users, but only for Larastan users. I hope you'll still accept it though.

I tried to implement it in a way that it will add `@return` doc tag if
- the method has a relation return type (There are other rectors to add missing return types)
- the method doesn't have any comments at all
- the method has comments but no existing `@return`
- the method only has 1 statement in body and it's `return` keyword. (this is how almost all Laravel relations are implemented)

From my local testing the only error I'm getting is about cognitive complexity. I don't know how I can reduce it more. Any tips for that would be great!