### PR TITLE
Revert RectorConfig->rule usage on config/config

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -17,5 +17,5 @@ return static function (RectorConfig $rectorConfig): void {
     $services->load('Rector\\Laravel\\', __DIR__ . '/../src')
         ->exclude([__DIR__ . '/../src/{Rector,ValueObject}']);
 
-    $rectorConfig->rule(RenameClassNonPhpRector::class);
+    $services->set(RenameClassNonPhpRector::class);
 };


### PR DESCRIPTION
To avoid error like:

```

                                                                                                                        
 [ERROR] Expected an instance of this class or to this class among his parents                                          
         Rector\Core\Contract\Rector\RectorInterface. Got: string in                                                    
         /Users/samsonasik/www/rector-symfony/config/config.php (which is being imported from                           
         "/Users/samsonasik/www/rector-symfony/rector.php").      
```