### PR TITLE
Add New Refactore Rule - Redirect Route To To Route Helper

### DIFF
--- a/docs/rector_rules_overview.md
+++ b/docs/rector_rules_overview.md
@@ -405,6 +405,31 @@ Replace `redirect()->back()` and `Redirect::back()` with `back()`
  }
 ```
 
+## RedirectRouteToToRouteHelperRector
+
+Replace `redirect()->route('home')` and `Redirect::route('home')` with `to_route('home')`
+
+- class: [`Rector\Laravel\Rector\MethodCall\RedirectRouteToToRouteHelperRector`](../src/Rector/MethodCall/RedirectRouteToToRouteHelperRector.php)
+
+```diff
+ use Illuminate\Support\Facades\Redirect;
+
+ class MyController
+ {
+     public function store()
+     {
+-        return redirect()->route('home')->with('error', 'Incorrect Details.')
++        return to_route('home')->with('error', 'Incorrect Details.')
+     }
+
+     public function update()
+     {
+-        return Redirect::route('home')->with('error', 'Incorrect Details.')
++        return to_route('home')->with('error', 'Incorrect Details.')
+     }
+ }
+```
+
 <br>
 
 ## RemoveAllOnDispatchingMethodsWithJobChainingRector

--- a/src/Rector/MethodCall/RedirectRouteToToRouteHelperRector.php
+++ b/src/Rector/MethodCall/RedirectRouteToToRouteHelperRector.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Laravel\Rector\MethodCall;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Name;
+use Rector\Core\Rector\AbstractRector;
+use Rector\Defluent\NodeAnalyzer\FluentChainMethodCallNodeAnalyzer;
+use Rector\NodeTypeResolver\Node\AttributeKey;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \Rector\Laravel\Tests\Rector\MethodCall\RedirectBackToBackHelperRector\RedirectBackToBackHelperRectorTest
+ */
+
+final class RedirectRouteToToRouteHelperRector extends AbstractRector
+{
+    public function __construct(
+        private readonly FluentChainMethodCallNodeAnalyzer $fluentChainMethodCallNodeAnalyzer,
+    ) {
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Replace `redirect()->route("home")` and `Redirect::route("home")` with `to_route("home")`',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+use Illuminate\Support\Facades\Redirect;
+
+class MyController
+{
+    public function store()
+    {
+        return redirect()->route('home')->with('error', 'Incorrect Details.')
+    }
+
+    public function update()
+    {
+        return Redirect::route('home')->with('error', 'Incorrect Details.')
+    }
+}
+CODE_SAMPLE
+                    ,
+                    <<<'CODE_SAMPLE'
+use Illuminate\Support\Facades\Redirect;
+
+class MyController
+{
+    public function store()
+    {
+        return to_route('home')->with('error', 'Incorrect Details.')
+    }
+
+    public function update()
+    {
+        return to_route('home')->with('error', 'Incorrect Details.')
+    }
+}
+CODE_SAMPLE
+                ),
+            ]
+        );
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [MethodCall::class, StaticCall::class];
+    }
+
+    /**
+     * @param MethodCall|StaticCall $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        if ($node instanceof MethodCall) {
+            return $this->updateRedirectHelperCall($node);
+        }
+
+        return $this->updateRedirectStaticCall($node);
+    }
+
+    private function updateRedirectHelperCall(MethodCall $methodCall): ?MethodCall
+    {
+        if (! $this->isName($methodCall->name, 'route')) {
+            return null;
+        }
+
+        $rootExpr = $this->fluentChainMethodCallNodeAnalyzer->resolveRootExpr($methodCall);
+        $parentNode = $rootExpr->getAttribute(AttributeKey::PARENT_NODE);
+
+        if (! $parentNode instanceof MethodCall) {
+            return null;
+        }
+
+        if (! $parentNode->var instanceof FuncCall) {
+            return null;
+        }
+
+        if ($parentNode->var->getArgs() !== []) {
+            return null;
+        }
+
+        if (! $this->isName($parentNode->var->name, 'redirect')) {
+            return null;
+        }
+
+        $this->removeNode($methodCall);
+
+        $parentNode->var->name = new Name('to_route', $methodCall->getArgs());
+        $parentNode->var->args = $methodCall->getArgs();
+
+        return $parentNode;
+    }
+
+    private function updateRedirectStaticCall(StaticCall $staticCall): ?FuncCall
+    {
+        if (! $this->isName($staticCall->class, 'Illuminate\Support\Facades\Redirect')) {
+            return null;
+        }
+
+        if (! $this->isName($staticCall->name, 'route')) {
+            return null;
+        }
+
+        return new FuncCall(new Name('to_route'), $staticCall->args);
+    }
+}

--- a/src/Rector/MethodCall/RedirectRouteToToRouteHelperRector.php
+++ b/src/Rector/MethodCall/RedirectRouteToToRouteHelperRector.php
@@ -117,7 +117,7 @@ CODE_SAMPLE
 
         $this->removeNode($methodCall);
 
-        $parentNode->var->name = new Name('to_route', $methodCall->getArgs());
+        $parentNode->var->name = new Name('to_route');
         $parentNode->var->args = $methodCall->getArgs();
 
         return $parentNode;

--- a/tests/Rector/MethodCall/RedirectRouteToToRouteHelperRector/Fixture/fixture.php.inc
+++ b/tests/Rector/MethodCall/RedirectRouteToToRouteHelperRector/Fixture/fixture.php.inc
@@ -1,0 +1,41 @@
+<?php
+
+namespace Rector\Laravel\Tests\Rector\MethodCall\RedirectBackToBackHelperRector\Fixture;
+
+use Illuminate\Support\Facades\Redirect;
+
+class Fixture
+{
+    public function store()
+    {
+        return redirect()->route('home')->with('error', 'Incorrect credential.');
+    }
+
+    public function update()
+    {
+        return Redirect::route('home')->with('error', 'Incorrect credential.');
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Laravel\Tests\Rector\MethodCall\RedirectBackToBackHelperRector\Fixture;
+
+use Illuminate\Support\Facades\Redirect;
+
+class Fixture
+{
+    public function store()
+    {
+        return to_route('home')->with('error', 'Incorrect credential.');
+    }
+
+    public function update()
+    {
+        return to_route('home')->with('error', 'Incorrect credential.');
+    }
+}
+
+?>

--- a/tests/Rector/MethodCall/RedirectRouteToToRouteHelperRector/Fixture/skip_with_object_call.php.inc
+++ b/tests/Rector/MethodCall/RedirectRouteToToRouteHelperRector/Fixture/skip_with_object_call.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+namespace Rector\Laravel\Tests\Rector\MethodCall\RedirectBackToBackHelperRector\Fixture;
+
+use Illuminate\Support\Facades\Redirect;
+
+class SkipWithObjectCall
+{
+    public function run(Redirect $redirect)
+    {
+        return $redirect->route('home')->with('error', 'Incorrect credential.');
+    }
+}
+
+?>

--- a/tests/Rector/MethodCall/RedirectRouteToToRouteHelperRector/Fixture/skip_with_only_back.php.inc
+++ b/tests/Rector/MethodCall/RedirectRouteToToRouteHelperRector/Fixture/skip_with_only_back.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\Laravel\Tests\Rector\MethodCall\RedirectBackToBackHelperRector\Fixture;
+
+class SkipWithOnlyBack
+{
+    public function run()
+    {
+        return to_route('home')->with('error', 'Incorrect credential.');
+    }
+}
+
+?>

--- a/tests/Rector/MethodCall/RedirectRouteToToRouteHelperRector/RedirectRouteToToRouteHelperRectorTest.php
+++ b/tests/Rector/MethodCall/RedirectRouteToToRouteHelperRector/RedirectRouteToToRouteHelperRectorTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Laravel\Tests\Rector\MethodCall\RedirectBackToBackHelperRector;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+final class RedirectRouteToToRouteHelperRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(SmartFileInfo $fileInfo): void
+    {
+        $this->doTestFileInfo($fileInfo);
+    }
+
+    /**
+     * @return Iterator<SmartFileInfo>
+     */
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Rector/MethodCall/RedirectRouteToToRouteHelperRector/config/configured_rule.php
+++ b/tests/Rector/MethodCall/RedirectRouteToToRouteHelperRector/config/configured_rule.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+
+use Rector\Laravel\Rector\MethodCall\RedirectRouteToToRouteHelperRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->import(__DIR__ . '/../../../../../config/config.php');
+
+    $rectorConfig->rule(RedirectRouteToToRouteHelperRector::class);
+};


### PR DESCRIPTION
This PR adds a new rule `RedirectRouteToToRouteHelperRector` to refactor the code around the redirect route.

Most of the Laravel developers redirect to the route location with the code like this:

```php
return redirect()->route('home')->with('...');
```

But there is a Laravel helper called [to_route](https://laravel.com/docs/9.x/helpers#method-to-route) that can be called directly and the `redirect()` call is not needed. The above line can be rewritten as:

```php
return to_route('home')->with('...');
```