### PR TITLE
[Laravel] Add RemoveDumpDataDeadCodeRector

### DIFF
--- a/docs/rector_rules_overview.md
+++ b/docs/rector_rules_overview.md
@@ -404,6 +404,7 @@ Replace `redirect()->back()` and `Redirect::back()` with `back()`
      }
  }
 ```
+<br>
 
 ## RedirectRouteToToRouteHelperRector
 
@@ -448,6 +449,30 @@ Remove `allOnQueue()` and `allOnConnection()` methods used with job chaining, us
 +    ->onQueue('podcasts')
 +    ->onConnection('redis')
 +    ->dispatch();
+```
+
+<br>
+
+## RedirectRouteToToRouteHelperRector
+
+It will removes the dump data just like dd or dump functions from the code.
+
+- class: [`Rector\Laravel\Rector\FuncCall\RemoveDumpDataDeadCodeRector`](../src/Rector/FuncCall/RemoveDumpDataDeadCodeRector.php)
+
+```diff
+ class MyController
+ {
+     public function store()
+     {
+-        dd('test');
+        return true;
+     }
+
+     public function update()
+     {
+-        dump('test');
+     }
+ }
 ```
 
 <br>

--- a/docs/rector_rules_overview.md
+++ b/docs/rector_rules_overview.md
@@ -471,6 +471,7 @@ It will removes the dump data just like dd or dump functions from the code.
      public function update()
      {
 -        dump('test');
+        return true;
      }
  }
 ```

--- a/src/Rector/FuncCall/RemoveDumpDataDeadCodeRector.php
+++ b/src/Rector/FuncCall/RemoveDumpDataDeadCodeRector.php
@@ -6,8 +6,9 @@ namespace Rector\Laravel\Rector\FuncCall;
 
 use PhpParser\Node;
 use PhpParser\Node\Expr\FuncCall;
-use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Stmt\Expression;
 use Rector\Core\Rector\AbstractRector;
+use Rector\NodeTypeResolver\Node\AttributeKey;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -68,7 +69,7 @@ CODE_SAMPLE
     }
 
     /**
-     * @param FuncCall|StaticCall $node
+     * @param FuncCall $node
      */
     public function refactor(Node $node): ?Node
     {
@@ -80,7 +81,13 @@ CODE_SAMPLE
             return null;
         }
 
+        $parentNode = $node->getAttribute(AttributeKey::PARENT_NODE);
+        if (! $parentNode instanceof Expression) {
+            return null;
+        }
+
         $this->removeNode($node);
+
         return null;
     }
 }

--- a/src/Rector/FuncCall/RemoveDumpDataDeadCodeRector.php
+++ b/src/Rector/FuncCall/RemoveDumpDataDeadCodeRector.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Laravel\Rector\FuncCall;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Expr\StaticCall;
+use Rector\Core\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \Rector\Laravel\Tests\Rector\FuncCall\RemoveDumpDataDeadCodeRector\RemoveDumpDataDeadCodeRectorTest
+ */
+
+final class RemoveDumpDataDeadCodeRector extends AbstractRector
+{
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'It will removes the dump data just like dd or dump functions from the code.`',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+class MyController
+{
+    public function store()
+    {
+        dd('test');
+        return true;
+    }
+
+    public function update()
+    {
+        dump('test');
+        return true;
+    }
+}
+CODE_SAMPLE
+                    ,
+                    <<<'CODE_SAMPLE'
+class MyController
+{
+    public function store()
+    {
+        return true;
+    }
+
+    public function update()
+    {
+        return true;
+    }
+}
+CODE_SAMPLE
+                ),
+            ]
+        );
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [FuncCall::class];
+    }
+
+    /**
+     * @param FuncCall|StaticCall $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        if (! $node instanceof FuncCall) {
+            return null;
+        }
+
+        if (! $this->isName($node->name, 'dd') && ! $this->isName($node->name, 'dump')) {
+            return null;
+        }
+
+        $this->removeNode($node);
+        return null;
+    }
+}

--- a/src/Rector/FuncCall/RemoveDumpDataDeadCodeRector.php
+++ b/src/Rector/FuncCall/RemoveDumpDataDeadCodeRector.php
@@ -73,10 +73,6 @@ CODE_SAMPLE
      */
     public function refactor(Node $node): ?Node
     {
-        if (! $node instanceof FuncCall) {
-            return null;
-        }
-
         if (! $this->isNames($node->name, ['dd', 'dump'])) {
             return null;
         }

--- a/src/Rector/FuncCall/RemoveDumpDataDeadCodeRector.php
+++ b/src/Rector/FuncCall/RemoveDumpDataDeadCodeRector.php
@@ -76,7 +76,7 @@ CODE_SAMPLE
             return null;
         }
 
-        if (! $this->isName($node->name, 'dd') && ! $this->isName($node->name, 'dump')) {
+        if (! $this->isNames($node->name, ['dd', 'dump'])) {
             return null;
         }
 

--- a/tests/Rector/FuncCall/RemoveDumpDataDeadCodeRector/Fixture/fixture.php.inc
+++ b/tests/Rector/FuncCall/RemoveDumpDataDeadCodeRector/Fixture/fixture.php.inc
@@ -1,0 +1,39 @@
+<?php
+
+namespace Rector\Laravel\Tests\Rector\FuncCall\RemoveDumpDataDeadCodeRector\Fixture;
+
+class Fixture
+{
+    public function store()
+    {
+        dd('test');
+        return true;
+    }
+
+    public function update()
+    {
+        dump('test');
+        return true;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Laravel\Tests\Rector\FuncCall\RemoveDumpDataDeadCodeRector\Fixture;
+
+class Fixture
+{
+    public function store()
+    {
+        return true;
+    }
+
+    public function update()
+    {
+        return true;
+    }
+}
+
+?>

--- a/tests/Rector/FuncCall/RemoveDumpDataDeadCodeRector/Fixture/skip_as_if_condition.php.inc
+++ b/tests/Rector/FuncCall/RemoveDumpDataDeadCodeRector/Fixture/skip_as_if_condition.php.inc
@@ -2,7 +2,7 @@
 
 namespace Rector\Laravel\Tests\Rector\FuncCall\RemoveDumpDataDeadCodeRector\Fixture;
 
-class SkipWithArguments
+class SkipAsIfCondition
 {
     public function run()
     {

--- a/tests/Rector/FuncCall/RemoveDumpDataDeadCodeRector/Fixture/skip_in_if_condition.php.inc
+++ b/tests/Rector/FuncCall/RemoveDumpDataDeadCodeRector/Fixture/skip_in_if_condition.php.inc
@@ -1,0 +1,17 @@
+<?php
+
+namespace Rector\Laravel\Tests\Rector\FuncCall\RemoveDumpDataDeadCodeRector\Fixture;
+
+class SkipWithArguments
+{
+    public function run()
+    {
+        if (dd('Tests')) {
+
+        }
+
+        return true;
+    }
+}
+
+?>

--- a/tests/Rector/FuncCall/RemoveDumpDataDeadCodeRector/Fixture/skip_with_object_call.php.inc
+++ b/tests/Rector/FuncCall/RemoveDumpDataDeadCodeRector/Fixture/skip_with_object_call.php.inc
@@ -1,0 +1,17 @@
+<?php
+
+namespace Rector\Laravel\Tests\Rector\FuncCall\RemoveDumpDataDeadCodeRector\Fixture;
+
+use Illuminate\Support\Facades\Redirect;
+
+class SkipWithObjectCall
+{
+    public function run(Object $object)
+    {
+        $object->dd();
+
+        return true;
+    }
+}
+
+?>

--- a/tests/Rector/FuncCall/RemoveDumpDataDeadCodeRector/Fixture/skip_with_relevant_name.php.inc
+++ b/tests/Rector/FuncCall/RemoveDumpDataDeadCodeRector/Fixture/skip_with_relevant_name.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\Laravel\Tests\Rector\FuncCall\RemoveDumpDataDeadCodeRector\Fixture;
+
+class SkipWithArguments
+{
+    public function run()
+    {
+        return ddTest();
+    }
+}
+
+?>

--- a/tests/Rector/FuncCall/RemoveDumpDataDeadCodeRector/RemoveDumpDataDeadCodeRectorTest.php
+++ b/tests/Rector/FuncCall/RemoveDumpDataDeadCodeRector/RemoveDumpDataDeadCodeRectorTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Laravel\Tests\Rector\FuncCall\RemoveDumpDataDeadCodeRector;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+final class RemoveDumpDataDeadCodeRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(SmartFileInfo $fileInfo): void
+    {
+        $this->doTestFileInfo($fileInfo);
+    }
+
+    /**
+     * @return Iterator<SmartFileInfo>
+     */
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Rector/FuncCall/RemoveDumpDataDeadCodeRector/config/configured_rule.php
+++ b/tests/Rector/FuncCall/RemoveDumpDataDeadCodeRector/config/configured_rule.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+
+use Rector\Laravel\Rector\FuncCall\RemoveDumpDataDeadCodeRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->import(__DIR__ . '/../../../../../config/config.php');
+
+    $rectorConfig->rule(RemoveDumpDataDeadCodeRector::class);
+};


### PR DESCRIPTION
This PR adds a new rule `RemoveDumpDataDeadCodeRector` to remove the unnecessary dump data code.

We are Humans And Human makes mistake sometimes we miss removing dump data code like `dd` or `dump` function calls.

That's why I added this new rector class to remove code that the developer forgot to remove.