### PR TITLE
Add set for Laravel 9.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ use Rector\Config\RectorConfig;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->sets([
-        LaravelSetList::LARAVEL_80
+        LaravelSetList::LARAVEL_90
     ]);
 };
 ```

--- a/config/sets/laravel90.php
+++ b/config/sets/laravel90.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPStan\Type\ArrayType;
+
+use PHPStan\Type\MixedType;
+use Rector\Arguments\Rector\ClassMethod\ArgumentAdderRector;
+use Rector\Arguments\ValueObject\ArgumentAdder;
+use Rector\Config\RectorConfig;
+use Rector\Core\ValueObject\Visibility;
+use Rector\Laravel\Rector\ClassMethod\AddArgumentDefaultValueRector;
+use Rector\Laravel\Rector\ClassMethod\AddParentRegisterToEventServiceProviderRector;
+use Rector\Laravel\Rector\MethodCall\RemoveAllOnDispatchingMethodsWithJobChainingRector;
+use Rector\Laravel\ValueObject\AddArgumentDefaultValue;
+use Rector\Renaming\Rector\MethodCall\RenameMethodRector;
+use Rector\Renaming\Rector\PropertyFetch\RenamePropertyRector;
+use Rector\Renaming\ValueObject\MethodCallRename;
+use Rector\Renaming\ValueObject\RenameProperty;
+use Rector\Visibility\ValueObject\ChangeMethodVisibility;
+
+# see https://laravel.com/docs/9.x/upgrade
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig
+        ->ruleWithConfiguration(ArgumentAdderRector::class, [new ArgumentAdder(
+            'Illuminate\Contracts\Foundation\Application',
+            'storagePath',
+            0,
+            'path',
+            ''
+        ),
+    ]);
+
+    $rectorConfig
+        ->ruleWithConfiguration(ArgumentAdderRector::class, [new ArgumentAdder(
+            'Illuminate\Contracts\Foundation\Application',
+            'langPath',
+            0,
+            'path',
+            ''
+        ),
+    ]);
+
+    $rectorConfig
+        ->ruleWithConfiguration(ChangeMethodVisibilityRector::class, [new ChangeMethodVisibility(
+            'Illuminate\Contracts\Foundation\Application',
+            'ignore',
+            Visibility::PUBLIC
+        ),
+    ]);
+
+
+    $rectorConfig
+        ->ruleWithConfiguration(RenameMethodRector::class, [
+            new MethodCallRename('Illuminate\Support\Enumerable', 'reduceWithKeys', 'reduce'),
+
+            new MethodCallRename('Illuminate\Support\Enumerable', 'reduceMany', 'reduceSpread'),
+        ]);
+};

--- a/config/sets/laravel90.php
+++ b/config/sets/laravel90.php
@@ -2,21 +2,12 @@
 
 declare(strict_types=1);
 
-use PHPStan\Type\ArrayType;
-
-use PHPStan\Type\MixedType;
 use Rector\Arguments\Rector\ClassMethod\ArgumentAdderRector;
 use Rector\Arguments\ValueObject\ArgumentAdder;
 use Rector\Config\RectorConfig;
 use Rector\Core\ValueObject\Visibility;
-use Rector\Laravel\Rector\ClassMethod\AddArgumentDefaultValueRector;
-use Rector\Laravel\Rector\ClassMethod\AddParentRegisterToEventServiceProviderRector;
-use Rector\Laravel\Rector\MethodCall\RemoveAllOnDispatchingMethodsWithJobChainingRector;
-use Rector\Laravel\ValueObject\AddArgumentDefaultValue;
 use Rector\Renaming\Rector\MethodCall\RenameMethodRector;
-use Rector\Renaming\Rector\PropertyFetch\RenamePropertyRector;
 use Rector\Renaming\ValueObject\MethodCallRename;
-use Rector\Renaming\ValueObject\RenameProperty;
 use Rector\Visibility\ValueObject\ChangeMethodVisibility;
 
 # see https://laravel.com/docs/9.x/upgrade
@@ -29,7 +20,7 @@ return static function (RectorConfig $rectorConfig): void {
             'path',
             ''
         ),
-    ]);
+        ]);
 
     $rectorConfig
         ->ruleWithConfiguration(ArgumentAdderRector::class, [new ArgumentAdder(
@@ -39,7 +30,7 @@ return static function (RectorConfig $rectorConfig): void {
             'path',
             ''
         ),
-    ]);
+        ]);
 
     $rectorConfig
         ->ruleWithConfiguration(ArgumentAdderRector::class, [new ArgumentAdder(
@@ -48,7 +39,7 @@ return static function (RectorConfig $rectorConfig): void {
             0,
             'attribute',
         ),
-    ]);
+        ]);
 
     $rectorConfig
         ->ruleWithConfiguration(ArgumentAdderRector::class, [new ArgumentAdder(
@@ -57,7 +48,7 @@ return static function (RectorConfig $rectorConfig): void {
             0,
             'hours',
         ),
-    ]);
+        ]);
 
     $rectorConfig
         ->ruleWithConfiguration(ArgumentAdderRector::class, [new ArgumentAdder(
@@ -66,13 +57,8 @@ return static function (RectorConfig $rectorConfig): void {
             0,
             'key',
         ),
-        new ArgumentAdder(
-            'Illuminate\Foundation\Http\FormRequest',
-            'validated',
-            1,
-            'default',
-        )
-    ]);
+            new ArgumentAdder('Illuminate\Foundation\Http\FormRequest', 'validated', 1, 'default',),
+        ]);
 
     $rectorConfig
         ->ruleWithConfiguration(ChangeMethodVisibilityRector::class, [new ChangeMethodVisibility(
@@ -80,7 +66,7 @@ return static function (RectorConfig $rectorConfig): void {
             'ignore',
             Visibility::PUBLIC
         ),
-    ]);
+        ]);
 
     $rectorConfig
         ->ruleWithConfiguration(RenameMethodRector::class, [
@@ -92,7 +78,11 @@ return static function (RectorConfig $rectorConfig): void {
 
             new MethodCallRename('Illuminate\Mail\Mailable', 'withSwiftMessage', 'withSymfonyMessage'),
 
-            new MethodCallRename('Illuminate\Notifications\Messages\MailMessage', 'withSwiftMessage', 'withSymfonyMessage'),
+            new MethodCallRename(
+                'Illuminate\Notifications\Messages\MailMessage',
+                'withSwiftMessage',
+                'withSymfonyMessage'
+            ),
 
             new MethodCallRename('Illuminate\Mail\Mailer', 'getSwiftMailer', 'getSymfonyTransport'),
 

--- a/config/sets/laravel90.php
+++ b/config/sets/laravel90.php
@@ -63,7 +63,7 @@ return static function (RectorConfig $rectorConfig): void {
             0,
             'key',
         ),
-            new ArgumentAdder('Illuminate\Foundation\Http\FormRequest', 'validated', 1, 'default', ),
+            new ArgumentAdder('Illuminate\Foundation\Http\FormRequest', 'validated', 1, 'default',),
         ]);
 
     // https://github.com/laravel/framework/commit/84c78b9f5f3dad58f92161069e6482f7267ffdb6

--- a/config/sets/laravel90.php
+++ b/config/sets/laravel90.php
@@ -42,6 +42,39 @@ return static function (RectorConfig $rectorConfig): void {
     ]);
 
     $rectorConfig
+        ->ruleWithConfiguration(ArgumentAdderRector::class, [new ArgumentAdder(
+            'Illuminate\Database\Eloquent\Model',
+            'touch',
+            0,
+            'attribute',
+        ),
+    ]);
+
+    $rectorConfig
+        ->ruleWithConfiguration(ArgumentAdderRector::class, [new ArgumentAdder(
+            'Illuminate\Queue\Failed\FailedJobProviderInterface',
+            'flush',
+            0,
+            'hours',
+        ),
+    ]);
+
+    $rectorConfig
+        ->ruleWithConfiguration(ArgumentAdderRector::class, [new ArgumentAdder(
+            'Illuminate\Foundation\Http\FormRequest',
+            'validated',
+            0,
+            'key',
+        ),
+        new ArgumentAdder(
+            'Illuminate\Foundation\Http\FormRequest',
+            'validated',
+            1,
+            'default',
+        )
+    ]);
+
+    $rectorConfig
         ->ruleWithConfiguration(ChangeMethodVisibilityRector::class, [new ChangeMethodVisibility(
             'Illuminate\Contracts\Foundation\Application',
             'ignore',
@@ -49,11 +82,24 @@ return static function (RectorConfig $rectorConfig): void {
         ),
     ]);
 
-
     $rectorConfig
         ->ruleWithConfiguration(RenameMethodRector::class, [
             new MethodCallRename('Illuminate\Support\Enumerable', 'reduceWithKeys', 'reduce'),
 
             new MethodCallRename('Illuminate\Support\Enumerable', 'reduceMany', 'reduceSpread'),
+
+            new MethodCallRename('Illuminate\Mail\Message', 'getSwiftMessage', 'getSymfonyMessage'),
+
+            new MethodCallRename('Illuminate\Mail\Mailable', 'withSwiftMessage', 'withSymfonyMessage'),
+
+            new MethodCallRename('Illuminate\Notifications\Messages\MailMessage', 'withSwiftMessage', 'withSymfonyMessage'),
+
+            new MethodCallRename('Illuminate\Mail\Mailer', 'getSwiftMailer', 'getSymfonyTransport'),
+
+            new MethodCallRename('Illuminate\Mail\Mailer', 'setSwiftMailer', 'setSymfonyTransport'),
+
+            new MethodCallRename('Illuminate\Mail\MailManager', 'createTransport', 'createSymfonyTransport'),
+
+            new MethodCallRename('Illuminate\Testing\TestResponse', 'assertDeleted', 'assertModelMissing'),
         ]);
 };

--- a/config/sets/laravel90.php
+++ b/config/sets/laravel90.php
@@ -8,6 +8,7 @@ use Rector\Config\RectorConfig;
 use Rector\Core\ValueObject\Visibility;
 use Rector\Renaming\Rector\MethodCall\RenameMethodRector;
 use Rector\Renaming\ValueObject\MethodCallRename;
+use Rector\Visibility\Rector\ClassMethod\ChangeMethodVisibilityRector;
 use Rector\Visibility\ValueObject\ChangeMethodVisibility;
 
 # see https://laravel.com/docs/9.x/upgrade
@@ -62,7 +63,7 @@ return static function (RectorConfig $rectorConfig): void {
             0,
             'key',
         ),
-            new ArgumentAdder('Illuminate\Foundation\Http\FormRequest', 'validated', 1, 'default',),
+            new ArgumentAdder('Illuminate\Foundation\Http\FormRequest', 'validated', 1, 'default', ),
         ]);
 
     // https://github.com/laravel/framework/commit/84c78b9f5f3dad58f92161069e6482f7267ffdb6

--- a/config/sets/laravel90.php
+++ b/config/sets/laravel90.php
@@ -12,6 +12,7 @@ use Rector\Visibility\ValueObject\ChangeMethodVisibility;
 
 # see https://laravel.com/docs/9.x/upgrade
 return static function (RectorConfig $rectorConfig): void {
+    // https://github.com/laravel/framework/commit/8f9ddea4481717943ed4ecff96d86b703c81a87d
     $rectorConfig
         ->ruleWithConfiguration(ArgumentAdderRector::class, [new ArgumentAdder(
             'Illuminate\Contracts\Foundation\Application',
@@ -22,9 +23,10 @@ return static function (RectorConfig $rectorConfig): void {
         ),
         ]);
 
+    // https://github.com/laravel/framework/commit/e6c8aaea886d35cc55bd3469f1a95ad56d53e474
     $rectorConfig
         ->ruleWithConfiguration(ArgumentAdderRector::class, [new ArgumentAdder(
-            'Illuminate\Contracts\Foundation\Application',
+            'Illuminate\Foundation\Application',
             'langPath',
             0,
             'path',
@@ -32,6 +34,7 @@ return static function (RectorConfig $rectorConfig): void {
         ),
         ]);
 
+    // https://github.com/laravel/framework/commit/e095ac0e928b5620f33c9b60816fde5ece867d32
     $rectorConfig
         ->ruleWithConfiguration(ArgumentAdderRector::class, [new ArgumentAdder(
             'Illuminate\Database\Eloquent\Model',
@@ -41,6 +44,7 @@ return static function (RectorConfig $rectorConfig): void {
         ),
         ]);
 
+    // https://github.com/laravel/framework/commit/6daecf43dd931dc503e410645ff4a7d611e3371f
     $rectorConfig
         ->ruleWithConfiguration(ArgumentAdderRector::class, [new ArgumentAdder(
             'Illuminate\Queue\Failed\FailedJobProviderInterface',
@@ -50,6 +54,7 @@ return static function (RectorConfig $rectorConfig): void {
         ),
         ]);
 
+    // https://github.com/laravel/framework/commit/8b40e8b7cba2fbf8337dfc05e3c6a62ae457e889
     $rectorConfig
         ->ruleWithConfiguration(ArgumentAdderRector::class, [new ArgumentAdder(
             'Illuminate\Foundation\Http\FormRequest',
@@ -57,12 +62,13 @@ return static function (RectorConfig $rectorConfig): void {
             0,
             'key',
         ),
-            new ArgumentAdder('Illuminate\Foundation\Http\FormRequest', 'validated', 1, 'default',),
+            new ArgumentAdder('Illuminate\Foundation\Http\FormRequest', 'validated', 1, 'default', ),
         ]);
 
+    // https://github.com/laravel/framework/commit/84c78b9f5f3dad58f92161069e6482f7267ffdb6
     $rectorConfig
         ->ruleWithConfiguration(ChangeMethodVisibilityRector::class, [new ChangeMethodVisibility(
-            'Illuminate\Contracts\Foundation\Application',
+            'Illuminate\Foundation\Exceptions\Handler',
             'ignore',
             Visibility::PUBLIC
         ),
@@ -70,26 +76,36 @@ return static function (RectorConfig $rectorConfig): void {
 
     $rectorConfig
         ->ruleWithConfiguration(RenameMethodRector::class, [
+            // https://github.com/laravel/framework/commit/9b4f011fb95c70444812f61d46c8e21fb5b66dd9
             new MethodCallRename('Illuminate\Support\Enumerable', 'reduceWithKeys', 'reduce'),
 
+            // https://github.com/laravel/framework/commit/02365bb5ebafeeaef28b5eb659466c56b2634c65
             new MethodCallRename('Illuminate\Support\Enumerable', 'reduceMany', 'reduceSpread'),
 
+            // https://github.com/laravel/framework/commit/097107ab50ce754c709313fc75a6f1f4a9389bfc
             new MethodCallRename('Illuminate\Mail\Message', 'getSwiftMessage', 'getSymfonyMessage'),
 
+            // https://github.com/laravel/framework/commit/097107ab50ce754c709313fc75a6f1f4a9389bfc
             new MethodCallRename('Illuminate\Mail\Mailable', 'withSwiftMessage', 'withSymfonyMessage'),
 
+            // https://github.com/laravel/framework/commit/097107ab50ce754c709313fc75a6f1f4a9389bfc
             new MethodCallRename(
                 'Illuminate\Notifications\Messages\MailMessage',
                 'withSwiftMessage',
                 'withSymfonyMessage'
             ),
 
+            // https://github.com/laravel/framework/commit/097107ab50ce754c709313fc75a6f1f4a9389bfc
             new MethodCallRename('Illuminate\Mail\Mailer', 'getSwiftMailer', 'getSymfonyTransport'),
 
+            // https://github.com/laravel/framework/commit/097107ab50ce754c709313fc75a6f1f4a9389bfc
             new MethodCallRename('Illuminate\Mail\Mailer', 'setSwiftMailer', 'setSymfonyTransport'),
 
+            // https://github.com/laravel/framework/commit/097107ab50ce754c709313fc75a6f1f4a9389bfc
             new MethodCallRename('Illuminate\Mail\MailManager', 'createTransport', 'createSymfonyTransport'),
 
+            // https://github.com/laravel/framework/commit/59ff96c269f691bfd197090675c0235700f750b2
+            // https://github.com/laravel/framework/commit/9894c2c64dc70f7dfda2ac46dfdaa8769ce4596a
             new MethodCallRename('Illuminate\Testing\TestResponse', 'assertDeleted', 'assertModelMissing'),
         ]);
 };

--- a/config/sets/laravel90.php
+++ b/config/sets/laravel90.php
@@ -62,7 +62,7 @@ return static function (RectorConfig $rectorConfig): void {
             0,
             'key',
         ),
-            new ArgumentAdder('Illuminate\Foundation\Http\FormRequest', 'validated', 1, 'default', ),
+            new ArgumentAdder('Illuminate\Foundation\Http\FormRequest', 'validated', 1, 'default',),
         ]);
 
     // https://github.com/laravel/framework/commit/84c78b9f5f3dad58f92161069e6482f7267ffdb6

--- a/config/sets/level/up-to-laravel-90.php
+++ b/config/sets/level/up-to-laravel-90.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+
+use Rector\Laravel\Set\LaravelLevelSetList;
+use Rector\Laravel\Set\LaravelSetList;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->sets([LaravelSetList::LARAVEL_90, LaravelLevelSetList::UP_TO_LARAVEL_80]);
+};

--- a/src/Set/LaravelLevelSetList.php
+++ b/src/Set/LaravelLevelSetList.php
@@ -62,4 +62,9 @@ final class LaravelLevelSetList implements SetListInterface
      * @var string
      */
     final public const UP_TO_LARAVEL_80 = __DIR__ . '/../../config/sets/level/up-to-laravel-80.php';
+
+    /**
+     * @var string
+     */
+    final public const UP_TO_LARAVEL_90 = __DIR__ . '/../../config/sets/level/up-to-laravel-90.php';
 }

--- a/src/Set/LaravelSetList.php
+++ b/src/Set/LaravelSetList.php
@@ -76,6 +76,11 @@ final class LaravelSetList implements SetListInterface
     /**
      * @var string
      */
+    final public const LARAVEL_90 = __DIR__ . '/../../config/sets/laravel90.php';
+
+    /**
+     * @var string
+     */
     final public const LARAVEL_STATIC_TO_INJECTION = __DIR__ . '/../../config/sets/laravel-static-to-injection.php';
 
     /**


### PR DESCRIPTION
- [x] Add argument
	- [x] The `storagePath` method of the `Illuminate\Contracts\Foundation\Application` interface has been updated to accept a path on the argument. [LINK](https://github.com/laravel/framework/commit/8f9ddea4481717943ed4ecff96d86b703c81a87d)
	- [x] The `langPath` method of the `Illuminate\Foundation\Application` class has been updated to accept a path on the argument. [LINK](https://github.com/laravel/framework/commit/e6c8aaea886d35cc55bd3469f1a95ad56d53e474)
	- [x] The `touch` method of the `Illuminate\Database\Eloquent\Model` abstract class has been updated to accept an attribute on the argument. [LINK](https://github.com/laravel/framework/commit/e095ac0e928b5620f33c9b60816fde5ece867d32)
	- [x] The `flush` method of the `Illuminate\Queue\Failed\FailedJobProviderInterface` abstract class has been updated to accept hours on the argument. [LINK](https://github.com/laravel/framework/commit/6daecf43dd931dc503e410645ff4a7d611e3371f)
	- [x] The `validated` method of the `Illuminate\Foundation\Http\FormRequest` abstract class has been updated to accept key and default values on the argument. [LINK](https://github.com/laravel/framework/commit/8b40e8b7cba2fbf8337dfc05e3c6a62ae457e889)

- [x] Change Method Visibility
	- [x] The `ignore` method of the `Illuminate\Foundation\Exceptions\Handler` class has been public. [LINK](https://github.com/laravel/framework/commit/84c78b9f5f3dad58f92161069e6482f7267ffdb6)
- [x] Rename method
	- [x] The `reduceWithKeys` method of the `Illuminate\Support\Enumerable` class has been removed. Instead, please use the `reduce` method.  [LINK](https://github.com/laravel/framework/commit/9b4f011fb95c70444812f61d46c8e21fb5b66dd9)
	- [x] The `reduceMany` method of the `Illuminate\Support\Enumerable` class has been removed. Instead, please use the `reduceSpread` method.  [LINK](https://github.com/laravel/framework/commit/02365bb5ebafeeaef28b5eb659466c56b2634c65)
	- [x] The `getSwiftMessage` method of the `Illuminate\Mail\Message` class has been removed. Instead, please use the `getSymfonyMessage` method.  [LINK](https://github.com/laravel/framework/commit/097107ab50ce754c709313fc75a6f1f4a9389bfc)
	- [x] The `withSwiftMessage` method of the `Illuminate\Mail\Mailable` class has been removed. Instead, please use the `withSymfonyMessage` method.  [LINK](https://github.com/laravel/framework/commit/097107ab50ce754c709313fc75a6f1f4a9389bfc)
	- [x] The `withSwiftMessage` method of the `Illuminate\Notifications\Messages\MailMessage` class has been removed. Instead, please use the `withSymfonyMessage` method.  [LINK](https://github.com/laravel/framework/commit/097107ab50ce754c709313fc75a6f1f4a9389bfc)
	- [x] The `getSwiftMailer` method of the `Illuminate\Mail\Mailer` class has been removed. Instead, please use the `getSymfonyTransport` method.  [LINK](https://github.com/laravel/framework/commit/097107ab50ce754c709313fc75a6f1f4a9389bfc)
	- [x] The `setSwiftMailer` method of the `Illuminate\Mail\Mailer` class has been removed. Instead, please use the `setSymfonyTransport` method.  [LINK](https://github.com/laravel/framework/commit/097107ab50ce754c709313fc75a6f1f4a9389bfc)
	- [x] The `createTransport` method of the `Illuminate\Mail\MailManager` class has been removed. Instead, please use the `createSymfonyTransport` method.  [LINK](https://github.com/laravel/framework/commit/097107ab50ce754c709313fc75a6f1f4a9389bfc)
	- [x] The `assertDeleted` method of the `Illuminate\Testing\TestResponse` class has been removed. Instead, please use the `assertModelMissing` method.  [LINK](https://github.com/laravel/framework/commit/59ff96c269f691bfd197090675c0235700f750b2) and [LINK](https://github.com/laravel/framework/commit/9894c2c64dc70f7dfda2ac46dfdaa8769ce4596a)

Closes #38 