### PR TITLE
[Laravel] Handle SetUpClassMethodNodeManipulator service not found

### DIFF
--- a/src/Rector/Class_/AddMockConsoleOutputFalseToConsoleTestsRector.php
+++ b/src/Rector/Class_/AddMockConsoleOutputFalseToConsoleTestsRector.php
@@ -14,6 +14,7 @@ use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Expression;
 use PHPStan\Type\ObjectType;
+use Rector\Core\Enum\ObjectReference;
 use Rector\Core\NodeAnalyzer\PropertyFetchAnalyzer;
 use Rector\Core\Rector\AbstractRector;
 use Rector\Core\ValueObject\MethodName;
@@ -113,7 +114,7 @@ CODE_SAMPLE
         if (! $setUpClassMethod instanceof ClassMethod) {
             $setUpClassMethod = new ClassMethod(MethodName::SET_UP);
             $setUpClassMethod->stmts = [
-                new Expression(new StaticCall(new Name('parent'), 'setUp')),
+                new Expression(new StaticCall(new Name(ObjectReference::PARENT), MethodName::SET_UP)),
                 new Expression($assign),
             ];
             $this->setUpMethodDecorator->decorate($setUpClassMethod);

--- a/src/Rector/Class_/AddMockConsoleOutputFalseToConsoleTestsRector.php
+++ b/src/Rector/Class_/AddMockConsoleOutputFalseToConsoleTestsRector.php
@@ -9,11 +9,16 @@ use PhpParser\Node\Expr\Assign;
 use PhpParser\Node\Expr\PropertyFetch;
 use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Name;
 use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Expression;
 use PHPStan\Type\ObjectType;
 use Rector\Core\NodeAnalyzer\PropertyFetchAnalyzer;
 use Rector\Core\Rector\AbstractRector;
-use Rector\PHPUnit\NodeManipulator\SetUpClassMethodNodeManipulator;
+use Rector\Core\ValueObject\MethodName;
+use Rector\PHPUnit\NodeAnalyzer\SetUpMethodDecorator;
+use Rector\Privatization\NodeManipulator\VisibilityManipulator;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -27,7 +32,8 @@ final class AddMockConsoleOutputFalseToConsoleTestsRector extends AbstractRector
 {
     public function __construct(
         private readonly PropertyFetchAnalyzer $propertyFetchAnalyzer,
-        private readonly SetUpClassMethodNodeManipulator $setUpClassMethodNodeManipulator
+        private readonly SetUpMethodDecorator $setUpMethodDecorator,
+        private readonly VisibilityManipulator $visibilityManipulator
     ) {
     }
 
@@ -102,7 +108,21 @@ CODE_SAMPLE
         }
 
         $assign = $this->createAssign();
-        $this->setUpClassMethodNodeManipulator->decorateOrCreate($node, [$assign]);
+
+        $setUpClassMethod = $node->getMethod(MethodName::SET_UP);
+        if (! $setUpClassMethod instanceof ClassMethod) {
+            $setUpClassMethod = new ClassMethod(MethodName::SET_UP);
+            $setUpClassMethod->stmts = [
+                new Expression(new StaticCall(new Name('parent'), 'setUp')),
+                new Expression($assign),
+            ];
+            $this->setUpMethodDecorator->decorate($setUpClassMethod);
+            $this->visibilityManipulator->makeProtected($setUpClassMethod);
+
+            $node->stmts = array_merge([$setUpClassMethod], $node->stmts);
+        } else {
+            $setUpClassMethod->stmts = array_merge((array) $setUpClassMethod->stmts, [new Expression($assign)]);
+        }
 
         return $node;
     }


### PR DESCRIPTION
`SetUpClassMethodNodeManipulator` is removed at https://github.com/rectorphp/rector-phpunit/pull/90.

This PR handle it.